### PR TITLE
pkg-config improvements

### DIFF
--- a/cairo-sys-rs/Cargo.toml
+++ b/cairo-sys-rs/Cargo.toml
@@ -24,4 +24,4 @@ name = "cairo_sys"
 libc = "0.2"
 
 [build-dependencies]
-pkg-config = "0.3.5"
+pkg-config = "0.3.7"

--- a/cairo-sys-rs/build.rs
+++ b/cairo-sys-rs/build.rs
@@ -1,4 +1,6 @@
 extern crate pkg_config;
+
+use pkg_config::{Config, Error};
 use std::env;
 use std::io::prelude::*;
 use std::io;
@@ -11,45 +13,52 @@ fn main() {
     }
 }
 
-fn find() -> Result<(), String> {
+fn find() -> Result<(), Error> {
     let package_name = "cairo";
     let shared_libs = ["cairo"];
-    let expected_version =
-        if cfg!(feature = "1.14") {
-            "1.14"
-        } else if cfg!(feature = "1.12") {
-            "1.12"
-        } else {
-            "1.10"
-        };
+    let version = if cfg!(feature = "1.14") {
+        "1.14"
+    } else if cfg!(feature = "1.12") {
+        "1.12"
+    } else {
+        "1.10"
+    };
 
     if let Ok(lib_dir) = env::var("GTK_LIB_DIR") {
         for lib_ in shared_libs.iter() {
             println!("cargo:rustc-link-lib=dylib={}", lib_);
         }
         println!("cargo:rustc-link-search=native={}", lib_dir);
-        Ok(())
-    } else {
-        let lib = try!(pkg_config::find_library(package_name));
-        if Version::new(&lib.version) >= Version::new(expected_version) {
+        return Ok(())
+    }
+
+    let target = env::var("TARGET").unwrap();
+    let hardcode_shared_libs = target.contains("windows");
+
+    let mut config = Config::new();
+    config.atleast_version(version);
+    if hardcode_shared_libs {
+        config.cargo_metadata(false);
+    }
+    match config.probe(package_name) {
+        Ok(library) => {
+            if hardcode_shared_libs {
+                for lib_ in shared_libs.iter() {
+                    println!("cargo:rustc-link-lib=dylib={}", lib_);
+                }
+                for path in library.link_paths.iter() {
+                    println!("cargo:rustc-link-search=native={}", path.to_str().unwrap());
+                }
+            }
             Ok(())
-        } else {
-            Err(format!("Installed `{}` version `{}` lower than `{}` requested by cargo features",
-                        package_name, lib.version, expected_version))
         }
+        Err(Error::EnvNoPkgConfig(_)) | Err(Error::Command { .. }) => {
+            for lib_ in shared_libs.iter() {
+                println!("cargo:rustc-link-lib=dylib={}", lib_);
+            }
+            Ok(())
+        }
+        Err(err) => Err(err),
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-struct Version(pub u16, pub u16, pub u16);
-
-impl Version {
-    fn new(s: &str) -> Version {
-        let mut parts = s.splitn(4, '.')
-            .map(|s| s.parse())
-            .take_while(Result::is_ok)
-            .map(Result::unwrap);
-        Version(parts.next().unwrap_or(0),
-            parts.next().unwrap_or(0), parts.next().unwrap_or(0))
-    }
-}


### PR DESCRIPTION
Update pkg-config to 0.3.7.
Let pkg-config compare version numbers.
If pkg-config can't be run emit hardcoded library names.
On Windows always emit hardcoded library names to avoid the `-lmm32` issue.