### PR TITLE
Reexport IoError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@ pub use enums::{
     SurfaceType,
 };
 
+pub use error::IoError;
+
 pub use patterns::{
     //Traits
     Pattern,


### PR DESCRIPTION
It's as good as private right now, I'm surprised the compiler allows that.