### PR TITLE
Implement safe ImageSurface::get_data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ optional = true
 
 [dependencies.cairo-sys-rs]
 path = "cairo-sys-rs"
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies.glib]
 git = "https://github.com/gtk-rs/glib"

--- a/cairo-sys-rs/Cargo.toml
+++ b/cairo-sys-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cairo-sys-rs"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["The Gtk-rs Project Developers"]
 build = "build.rs"
 links = "cairo"

--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -447,6 +447,8 @@ extern "C" {
     pub fn cairo_surface_reference(surface: *mut cairo_surface_t) -> *mut cairo_surface_t;
     pub fn cairo_surface_get_user_data(surface: *mut cairo_surface_t, key: *mut cairo_user_data_key_t) -> *mut c_void;
     pub fn cairo_surface_set_user_data(surface: *mut cairo_surface_t, key: *mut cairo_user_data_key_t, user_data: *mut c_void, destroy: cairo_destroy_func_t) -> Status;
+    pub fn cairo_surface_get_reference_count(surface: *mut cairo_surface_t) -> c_uint;
+    pub fn cairo_surface_mark_dirty(surface: *mut cairo_surface_t);
 
     // CAIRO IMAGE SURFACE
     pub fn cairo_image_surface_create(format: Format, width: c_int, height: c_int) -> *mut cairo_surface_t;

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,4 +6,19 @@ use std::io;
 use ffi::enums::Status;
 
 #[derive(Debug)]
+pub enum BorrowError { Cairo(Status), NonExclusive }
+
+impl From<Status> for BorrowError {
+    fn from(status: Status) -> Self {
+        BorrowError::Cairo(status)
+    }
+}
+
+#[derive(Debug)]
 pub enum IoError { Cairo(Status), Io(io::Error) }
+
+impl From<Status> for IoError {
+    fn from(status: Status) -> Self {
+        IoError::Cairo(status)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,10 @@ pub use enums::{
     SurfaceType,
 };
 
-pub use error::IoError;
+pub use error::{
+    BorrowError,
+    IoError,
+};
 
 pub use patterns::{
     //Traits
@@ -71,8 +74,12 @@ pub use matrices::{
 
 pub use rectangle::RectangleInt;
 
-pub use image_surface::ImageSurface;
 pub use surface::Surface;
+
+pub use image_surface::{
+    ImageSurface,
+    ImageSurfaceData,
+};
 
 pub mod prelude;
 


### PR DESCRIPTION
Allow borrowing the underlying data when the reference to the surface is unique. The binding manages flushing and dirtying automatically.
cc #74

Implement Deref for ImageSurface.