### PR TITLE
Make Surface struct fields public

### DIFF
--- a/src/surface.rs
+++ b/src/surface.rs
@@ -13,7 +13,7 @@ use ffi::enums::{
 };
 
 #[derive(Debug)]
-pub struct Surface(*mut ffi::cairo_surface_t);
+pub struct Surface(pub *mut ffi::cairo_surface_t);
 
 impl Surface {
     pub fn status(&self) -> Status {


### PR DESCRIPTION
Hi, 
I've create cairo-xcb bindings and it needed that Surface struct's fields to be a public. I create surface from a pointer and create context as:

```rust
    let csurface = xcb_surface_create(&conn, window, &visual, 150, 150);
    let surface = Surface(csurface);
    let cr = cairo::Context::new(&surface);
```