### PR TITLE
Implement Gradient trait for RadialGradient

### DIFF
--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -245,6 +245,8 @@ impl RadialGradient {
     }
 }
 
+impl Gradient for RadialGradient{}
+
 
 pattern_type!(SurfacePattern);
 


### PR DESCRIPTION
I could be wrong about this, maybe I'm just missing something. Shouldn't the Gradient trait be implemented for RadialGradient?