### PR TITLE
Refactor Path

### DIFF
--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -236,7 +236,7 @@ extern "C" {
     pub fn cairo_copy_path(cr: *mut cairo_t) -> *mut cairo_path_t;
     pub fn cairo_copy_path_flat(cr: *mut cairo_t) -> *mut cairo_path_t;
     pub fn cairo_path_destroy(path: *mut cairo_path_t);
-    pub fn cairo_append_path(cr: *mut cairo_t, path: *mut cairo_path_t);
+    pub fn cairo_append_path(cr: *mut cairo_t, path: *const cairo_path_t);
     pub fn cairo_has_current_point(cr: *mut cairo_t) -> cairo_bool_t;
     pub fn cairo_get_current_point(cr: *mut cairo_t, x: *mut c_double, y: *mut c_double);
     pub fn cairo_new_path(cr: *mut cairo_t);

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,7 +6,7 @@ use glib::translate::*;
 use c_vec::CVec;
 use std::mem::transmute;
 use libc::{c_double, c_int};
-use ::paths::Path;
+use paths::{BoxedPath, Path};
 use ::fonts::{TextExtents, TextCluster, FontExtents, ScaledFont, FontOptions, FontFace, Glyph};
 use ::matrices::{Matrix, MatrixTrait};
 use ffi::enums::{
@@ -694,21 +694,21 @@ impl Context {
 
     // paths stuff
 
-    pub fn copy_path(&self) -> Path {
+    pub fn copy_path(&self) -> BoxedPath {
         unsafe {
-            Path::wrap(ffi::cairo_copy_path(self.0))
+            from_glib_full(ffi::cairo_copy_path(self.0))
         }
     }
 
-    pub fn copy_path_flat(&self) -> Path {
+    pub fn copy_path_flat(&self) -> BoxedPath {
         unsafe {
-            Path::wrap(ffi::cairo_copy_path_flat(self.0))
+            from_glib_full(ffi::cairo_copy_path_flat(self.0))
         }
     }
 
     pub fn append_path(&self, path: &Path) {
         unsafe {
-            ffi::cairo_append_path(self.0, path.get_ptr())
+            ffi::cairo_append_path(self.0, path.to_glib_none().0)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub use context::{
 };
 
 pub use paths::{
+    BoxedPath,
     Path,
     PathSegments,
     PathSegment


### PR DESCRIPTION
Make `Path` a newtype over `cairo_path_t` and introduce `BoxedPath`, an owned pointer to `Path`.

`BoxedPath` has a library-specific destructor and should only be returned by this crate. Other crates can import `Path` and define their own `BoxedPath` variants with appropriate destructors.

This should solve the destructor mismatch pointed out in https://github.com/gtk-rs/cairo/issues/88#issuecomment-257510285.

@federicomenaquintero With this change you can import `Path` from this crate and define your own `BoxedPath` with a different destructor.