### PR TITLE
Fixing typo in LineJoin enum

### DIFF
--- a/cairo-sys-rs/src/enums.rs
+++ b/cairo-sys-rs/src/enums.rs
@@ -108,7 +108,7 @@ pub enum LineCap {
 pub enum LineJoin {
     Miter,
     Round,
-    nBevel
+    Bevel
 }
 
 #[repr(C)]


### PR DESCRIPTION
There should be `Bevel` not `nBevel`. Reference: https://www.cairographics.org/manual/cairo-cairo-t.html#cairo-line-join-t