### PR TITLE
Remove CVec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,3 @@ version = "0.1.1"
 
 [dependencies]
 libc = "0.2"
-c_vec = "~1.0"

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,8 +3,8 @@
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
 use glib::translate::*;
-use c_vec::CVec;
 use std::mem::transmute;
+use std::slice::from_raw_parts;
 use libc::{c_double, c_int};
 use ::paths::Path;
 use ::fonts::{TextExtents, TextCluster, FontExtents, ScaledFont, FontOptions, FontFace, Glyph};
@@ -26,12 +26,12 @@ use ffi::enums::{Status, Antialias, LineCap, LineJoin, FillRule};
 use ::patterns::{wrap_pattern, Pattern};
 use surface::Surface;
 
-pub struct RectangleVec {
+pub struct RectangleVec<'a> {
     ptr: *mut cairo_rectangle_list_t,
-    pub rectangles: CVec<Rectangle>,
+    pub rectangles: &'a[Rectangle], // Vec<Rectangle>,
 }
 
-impl Drop for RectangleVec {
+impl<'a> Drop for RectangleVec<'a> {
     fn drop(&mut self) {
         unsafe {
             ffi::cairo_rectangle_list_destroy(self.ptr);
@@ -355,7 +355,7 @@ impl Context {
 
             RectangleVec {
                 ptr: rectangle_list,
-                rectangles: CVec::new((*rectangle_list).rectangles,
+                rectangles: from_raw_parts((*rectangle_list).rectangles,
                                       (*rectangle_list).num_rectangles as usize),
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 extern crate cairo_sys as ffi;
 extern crate libc;
 extern crate glib;
-extern crate c_vec;
 
 pub use ffi::enums;
 pub use ffi::cairo_rectangle_t as Rectangle;


### PR DESCRIPTION
CVec dev-depends on libc 0.1 which I can't compile using rustc 1.14.0 because of

```
   Compiling libc v0.1.12 (file:///tmp/guix-build-rust-libc-0.1.12.drv-0/libc-0.1.12)
error[E0554]: #[feature] may not be used on the stable release channel
  --> rust/src/liblibc/lib.rs:26:19
   |
26 | #![cfg_attr(test, feature(test))]
   |                   ^^^^^^^^^^^^^

error: aborting due to previous error
```

The current libc is 0.2 which is incompatible with 0.1.

Only 8 Rust crates in total seem to still use c_vec - and many moved away.

Therefore, I removed c_vec from cairo-rs.

Note that I'm a beginner to Rust. However, the compilation worked and all the tests run by `cairo test` still pass.

The parts that still used CVec were:

- src/context.rs: `copy_clip_rectangle_list` which calls an FFI function which returns newly allocated memory, eventually freed via impl Drop (by us). Therefore, the lifetime of the newly allocated memory is the same as ours.
- src/paths.rs: `iter`: the PathSegments are part of the Path and therefore live as long as the Path does.