### PR TITLE
implement wrappers for win32 surfaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ version = "0.1.1"
 [dependencies]
 libc = "0.2"
 c_vec = "~1.2"
+
+[target.'cfg(windows)'.dependencies]
+winapi = "0.2.7"

--- a/cairo-sys-rs/Cargo.toml
+++ b/cairo-sys-rs/Cargo.toml
@@ -25,5 +25,8 @@ v1_14 = ["v1_12"]
 libc = "0.2"
 x11 = { version = "2.6.1", features = ["xlib"], optional = true }
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.2.7"
+
 [build-dependencies]
 pkg-config = "0.3.7"

--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -9,6 +9,9 @@ extern crate libc;
 #[cfg(feature = "xlib")]
 extern crate x11;
 
+#[cfg(windows)]
+extern crate winapi;
+
 use libc::{c_void, c_int, c_uint, c_char, c_uchar, c_double, c_ulong};
 
 #[cfg(feature = "xlib")]
@@ -469,6 +472,7 @@ extern "C" {
     #[cfg(feature = "png")]
     pub fn cairo_surface_write_to_png_stream(surface: *mut cairo_surface_t, write_func: cairo_write_func_t, closure: *mut c_void) -> Status;
 
+    // CAIRO XLIB SURFACE
     #[cfg(feature = "xlib")]
     pub fn cairo_xlib_surface_create(dpy: *mut xlib::Display,
                                      drawable: xlib::Drawable,
@@ -514,4 +518,24 @@ extern "C" {
     pub fn cairo_xlib_surface_get_height(surface: *mut cairo_surface_t)
                                          -> c_int;
 
+    // CAIRO WINDOWS SURFACE
+    #[cfg(windows)]
+    pub fn cairo_win32_surface_create(hdc: winapi::HDC) -> *mut cairo_surface_t;
+    #[cfg(windows)]
+    pub fn cairo_win32_surface_create_with_dib(format: Format,
+                                               width: c_int,
+                                               height: c_int)
+                                               -> *mut cairo_surface_t;
+    #[cfg(windows)]
+    pub fn cairo_win32_surface_create_with_ddb(hdc: winapi::HDC,
+                                               format: Format,
+                                               width: c_int,
+                                               height: c_int)
+                                               -> *mut cairo_surface_t;
+    #[cfg(windows)]
+    pub fn cairo_win32_printing_surface_create(hdc: winapi::HDC) -> *mut cairo_surface_t;
+    #[cfg(windows)]
+    pub fn cairo_win32_surface_get_dc(surface: *mut cairo_surface_t) -> winapi::HDC;
+    #[cfg(windows)]
+    pub fn cairo_win32_surface_get_image(surface: *mut cairo_surface_t) -> *mut cairo_surface_t;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,3 +96,9 @@ mod patterns;
 mod rectangle;
 mod surface;
 mod matrices;
+
+#[cfg(windows)]
+mod win32_surface;
+
+#[cfg(windows)]
+pub use win32_surface::Win32Surface;

--- a/src/win32_surface.rs
+++ b/src/win32_surface.rs
@@ -1,0 +1,89 @@
+// Copyright 2017, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+extern crate winapi;
+
+use std::ops::Deref;
+
+use glib::translate::*;
+use ffi;
+use ffi::enums::{Format, SurfaceType};
+use surface::{Surface, SurfaceExt};
+
+#[derive(Debug)]
+pub struct Win32Surface(Surface);
+
+impl Win32Surface {
+    pub fn from(surface: Surface) -> Result<Win32Surface, Surface> {
+        if surface.get_type() == SurfaceType::Win32 {
+            Ok(Win32Surface(surface))
+        } else {
+            Err(surface)
+        }
+    }
+
+    pub fn create(hdc: winapi::HDC) -> Win32Surface {
+        unsafe { from_glib_full(ffi::cairo_win32_surface_create(hdc)) }
+    }
+
+    pub fn create_with_dib(format: Format, width: i32, height: i32) -> Win32Surface {
+        unsafe { from_glib_full(ffi::cairo_win32_surface_create_with_dib(format, width, height)) }
+    }
+
+    pub fn create_with_ddb(hdc: winapi::HDC,
+                           format: Format,
+                           width: i32,
+                           height: i32)
+                           -> Win32Surface {
+        unsafe {
+            from_glib_full(ffi::cairo_win32_surface_create_with_ddb(hdc, format, width, height))
+        }
+    }
+
+    pub fn printing_surface_create(hdc: winapi::HDC) -> Win32Surface {
+        unsafe { from_glib_full(ffi::cairo_win32_printing_surface_create(hdc)) }
+    }
+}
+
+impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Win32Surface {
+    type Storage = &'a Surface;
+
+    #[inline]
+    fn to_glib_none(&'a self) -> Stash<'a, *mut ffi::cairo_surface_t, Self> {
+        let stash = self.0.to_glib_none();
+        Stash(stash.0, stash.1)
+    }
+}
+
+impl FromGlibPtr<*mut ffi::cairo_surface_t> for Win32Surface {
+    #[inline]
+    unsafe fn from_glib_none(ptr: *mut ffi::cairo_surface_t) -> Win32Surface {
+        Self::from(from_glib_none(ptr)).unwrap()
+    }
+
+    #[inline]
+    unsafe fn from_glib_full(ptr: *mut ffi::cairo_surface_t) -> Win32Surface {
+        Self::from(from_glib_full(ptr)).unwrap()
+    }
+}
+
+impl AsRef<Surface> for Win32Surface {
+    fn as_ref(&self) -> &Surface {
+        &self.0
+    }
+}
+
+impl Deref for Win32Surface {
+    type Target = Surface;
+
+    fn deref(&self) -> &Surface {
+        &self.0
+    }
+}
+
+impl Clone for Win32Surface {
+    fn clone(&self) -> Win32Surface {
+        unsafe { from_glib_none(self.to_glib_none().0) }
+    }
+}


### PR DESCRIPTION
These changes implement enough win32 surfaces for me to succeed at porting a small program of mine to Windows.

Some things I'm not sure about:
- do I bump the version number in cairo-sys-rs?
- I mostly just followed ImageSurface, is that the right thing to do?