### PR TITLE
Implement missing methods for patterns and surfaces

### DIFF
--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -21,6 +21,7 @@ pub mod enums;
 
 use enums::{
     Status,
+    Content,
     Antialias,
     LineCap,
     LineJoin,
@@ -180,7 +181,7 @@ extern "C" {
     pub fn cairo_restore (cr: *mut cairo_t);
     pub fn cairo_get_target (cr: *mut cairo_t) -> *mut cairo_surface_t;
     pub fn cairo_push_group (cr: *mut cairo_t);
-    pub fn cairo_push_group_with_content (cr: *mut cairo_t, content: cairo_content_t);
+    pub fn cairo_push_group_with_content (cr: *mut cairo_t, content: Content);
     pub fn cairo_pop_group (cr: *mut cairo_t) -> *mut cairo_pattern_t;
     pub fn cairo_pop_group_to_source (cr: *mut cairo_t);
     pub fn cairo_get_group_target (cr: *mut cairo_t) -> *mut cairo_surface_t;
@@ -365,7 +366,7 @@ extern "C" {
     pub fn cairo_text_cluster_free(clusters: *mut TextCluster);
 
     //CAIRO RASTER
-    //pub fn cairo_pattern_create_raster_source(user_data: *mut void, content: cairo_content_t, width: c_int, height: c_int) -> *mut cairo_pattern_t;
+    //pub fn cairo_pattern_create_raster_source(user_data: *mut void, content: Content, width: c_int, height: c_int) -> *mut cairo_pattern_t;
     //pub fn cairo_raster_source_pattern_set_callback_data(pattern: *mut cairo_pattern_t, data: *mut void);
     //pub fn cairo_raster_source_pattern_get_callback_data(pattern: *mut cairo_pattern_t) -> *mut void;
     /* FIXME how do we do these _func_t types?
@@ -458,6 +459,7 @@ extern "C" {
     pub fn cairo_surface_set_user_data(surface: *mut cairo_surface_t, key: *mut cairo_user_data_key_t, user_data: *mut c_void, destroy: cairo_destroy_func_t) -> Status;
     pub fn cairo_surface_get_reference_count(surface: *mut cairo_surface_t) -> c_uint;
     pub fn cairo_surface_mark_dirty(surface: *mut cairo_surface_t);
+    pub fn cairo_surface_create_similar(surface: *mut cairo_surface_t, content: Content, width: c_int, height: c_int) -> *mut cairo_surface_t;
 
     // CAIRO IMAGE SURFACE
     pub fn cairo_image_surface_create(format: Format, width: c_int, height: c_int) -> *mut cairo_surface_t;

--- a/src/context.rs
+++ b/src/context.rs
@@ -114,7 +114,11 @@ impl Context {
         self.ensure_status()
     }
 
-    //fn ffi::cairo_get_target(cr: *mut cairo_t) -> *mut cairo_surface_t;
+    pub fn get_target(&self) -> Surface {
+        unsafe {
+            from_glib_none(ffi::cairo_get_target(self.0))
+        }
+    }
 
     pub fn push_group(&self) {
         unsafe {
@@ -141,7 +145,11 @@ impl Context {
         }
     }
 
-    //fn ffi::cairo_get_group_target(cr: *mut cairo_t) -> *mut cairo_surface_t;
+    pub fn get_group_target(&self) -> Surface {
+        unsafe {
+            from_glib_none(ffi::cairo_get_group_target(self.0))
+        }
+    }
 
     pub fn set_source_rgb(&self, red: f64, green: f64, blue: f64) {
         unsafe {

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -8,6 +8,7 @@ use libc::c_void;
 use glib::translate::*;
 use ffi;
 use ffi::enums::{
+    Content,
     Status,
     SurfaceType,
 };
@@ -18,6 +19,10 @@ pub struct Surface(*mut ffi::cairo_surface_t);
 impl Surface {
     pub fn status(&self) -> Status {
         unsafe { ffi::cairo_surface_status(self.to_glib_none().0) }
+    }
+
+    pub fn create_similar(&self, content: Content, width: i32, height: i32) -> Surface {
+        unsafe { from_glib_full(ffi::cairo_surface_create_similar(self.to_glib_none().0, content, width, height)) }
     }
 }
 


### PR DESCRIPTION
These commits implement:
```
  Context.get_target() -> Surface
  Context.get_group_target() -> Surface
  Surface.create_similar() -> Surface
  SurfacePattern::create(surface)
  SurfacePattern.get_surface() -> Surface

```
I need these for librsvg :)