### PR TITLE
Reexport forgotten sys enums used in Pattern public functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,10 @@ pub use paths::{
 pub use enums::{
     Status,
     Antialias,
+    Content,
+    Extend,
     FillRule,
+    Filter,
     LineCap,
     LineJoin,
     Operator,


### PR DESCRIPTION
Fix #105 