### PR TITLE
Scaled fonts

### DIFF
--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -275,7 +275,7 @@ extern "C" {
     pub fn cairo_line_to(cr: *mut cairo_t, x: c_double, y: c_double);
     pub fn cairo_move_to(cr: *mut cairo_t, x: c_double, y: c_double);
     pub fn cairo_rectangle(cr: *mut cairo_t, x: c_double, y: c_double, width: c_double, height: c_double);
-    pub fn cairo_glyph_path(cr: *mut cairo_t, glyphs: *mut Glyph, num_glyphs: c_int);
+    pub fn cairo_glyph_path(cr: *mut cairo_t, glyphs: *const Glyph, num_glyphs: c_int);
     pub fn cairo_text_path(cr: *mut cairo_t, utf8: *const c_char);
     pub fn cairo_rel_curve_to(cr: *mut cairo_t, dx1: c_double, dy1: c_double, dx2: c_double, dy2: c_double, dx3: c_double, dy3: c_double);
     pub fn cairo_rel_line_to(cr: *mut cairo_t, dx: c_double, dy: c_double);

--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -430,9 +430,9 @@ extern "C" {
     //                    FontExtents;
     pub fn cairo_scaled_font_extents(scaled_font: *mut cairo_scaled_font_t, extents: *mut FontExtents);
     //                    TextExtents;
-    pub fn cairo_scaled_font_text_extents(scaled_font: *mut cairo_scaled_font_t, utf8: *mut c_char, extents: *mut TextExtents);
-    pub fn cairo_scaled_font_glyph_extents(scaled_font: *mut cairo_scaled_font_t, glyphs: *mut Glyph, num_glyphs: c_int, extents: *mut TextExtents);
-    pub fn cairo_scaled_font_text_to_glyphs(scaled_font: *mut cairo_scaled_font_t, x: c_double, y: c_double, utf8: *mut c_char, utf8_len: c_int, glyphs: *mut *mut Glyph, num_glyphs: *mut c_int, clusters: *mut *mut TextCluster, num_clusters: *mut c_int, cluster_flags: *mut TextClusterFlags) -> Status;
+    pub fn cairo_scaled_font_text_extents(scaled_font: *mut cairo_scaled_font_t, utf8: *const c_char, extents: *mut TextExtents);
+    pub fn cairo_scaled_font_glyph_extents(scaled_font: *mut cairo_scaled_font_t, glyphs: *const Glyph, num_glyphs: c_int, extents: *mut TextExtents);
+    pub fn cairo_scaled_font_text_to_glyphs(scaled_font: *mut cairo_scaled_font_t, x: c_double, y: c_double, utf8: *const c_char, utf8_len: c_int, glyphs: *mut *mut Glyph, num_glyphs: *mut c_int, clusters: *mut *mut TextCluster, num_clusters: *mut c_int, cluster_flags: *mut TextClusterFlags) -> Status;
     pub fn cairo_scaled_font_get_font_face(scaled_font: *mut cairo_scaled_font_t) -> *mut cairo_font_face_t;
     pub fn cairo_scaled_font_get_font_options(scaled_font: *mut cairo_scaled_font_t, options: *mut cairo_font_options_t);
     pub fn cairo_scaled_font_get_font_matrix(scaled_font: *mut cairo_scaled_font_t, font_matrix: *mut Matrix);

--- a/src/context.rs
+++ b/src/context.rs
@@ -811,7 +811,11 @@ impl Context {
         }
     }
 
-    //fn ffi::cairo_glyph_path(cr: *mut cairo_t, glyphs: *mut cairo_glyph_t, num_glyphs: isize);
+    pub fn glyph_path(&self, glyphs: &[Glyph]) {
+        unsafe {
+            ffi::cairo_glyph_path(self.0, glyphs.as_ptr(), glyphs.len() as i32)
+        }
+    }
 
     pub fn rel_curve_to(&self, dx1: f64, dy1: f64, dx2: f64, dy2: f64, dx3: f64, dy3: f64) {
         unsafe {

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -6,6 +6,7 @@ use glib::translate::*;
 use std::clone::Clone;
 use std::cmp::PartialEq;
 use std::ops::Drop;
+use std::ptr;
 use ffi;
 
 pub use ffi::enums::{
@@ -17,8 +18,12 @@ pub use ffi::enums::{
     FontType,
     FontWeight,
     FontSlant,
+    TextClusterFlags,
 };
-use ::matrices::Matrix;
+use ::matrices::{
+    Matrix,
+    MatrixTrait
+};
 use ffi::{
     cairo_font_options_t,
     cairo_font_face_t,
@@ -275,24 +280,154 @@ impl ScaledFont {
         }
     }
 
-    //pub fn cairo_scaled_font_extents(scaled_font: *mut cairo_scaled_font_t, extents: *mut cairo_font_extents_t);
+    pub fn extents(&self) -> FontExtents {
+        let mut extents = FontExtents {
+            ascent: 0.0,
+            descent: 0.0,
+            height: 0.0,
+            max_x_advance: 0.0,
+            max_y_advance: 0.0,
+        };
 
-    //                    cairo_text_extents_t;
-    //pub fn cairo_scaled_font_text_extents(scaled_font: *mut cairo_scaled_font_t, utf8: *mut char, extents: *mut cairo_text_extents_t);
+        unsafe {
+            ffi::cairo_scaled_font_extents(self.get_ptr(), &mut extents)
+        }
 
-    //pub fn cairo_scaled_font_glyph_extents(scaled_font: *mut cairo_scaled_font_t, glyphs: *mut Glyph, num_glyphs: c_int, extents: *mut cairo_text_extents_t);
+        extents
+    }
 
-    //pub fn cairo_scaled_font_text_to_glyphs(scaled_font: *mut cairo_scaled_font_t, x: c_double, y: c_double, utf8: *mut char, utf8_len: c_int, glyphs: **mut Glyph, num_glyphs: *mut c_int, clusters: **mut TextCluster, num_clusters: *mut c_int, cluster_flags: *mut TextClusterFlags) -> Status;
+    pub fn text_extents(&self, text: &str) -> TextExtents {
+        let mut extents = TextExtents {
+            x_bearing: 0.0,
+            y_bearing: 0.0,
+            width: 0.0,
+            height: 0.0,
+            x_advance: 0.0,
+            y_advance: 0.0,
+        };
 
-    //pub fn cairo_scaled_font_get_font_face(scaled_font: *mut cairo_scaled_font_t) -> *mut cairo_font_face_t;
+        unsafe {
+            ffi::cairo_scaled_font_text_extents(self.get_ptr(), text.to_glib_none().0, &mut extents)
+        }
 
-    //pub fn cairo_scaled_font_get_font_options(scaled_font: *mut cairo_scaled_font_t, options: *mut cairo_font_options_t);
+        extents
+    }
 
-    //pub fn cairo_scaled_font_get_font_matrix(scaled_font: *mut cairo_scaled_font_t, font_matrix: *mut cairo_matrix_t);
+    pub fn glyph_extents(&self, glyphs: &[Glyph]) -> TextExtents {
+        let mut extents = TextExtents {
+            x_bearing: 0.0,
+            y_bearing: 0.0,
+            width: 0.0,
+            height: 0.0,
+            x_advance: 0.0,
+            y_advance: 0.0,
+        };
 
-    //pub fn cairo_scaled_font_get_ctm(scaled_font: *mut cairo_scaled_font_t, ctm: *mut cairo_matrix_t);
+        unsafe {
+            ffi::cairo_scaled_font_glyph_extents(self.get_ptr(), glyphs.as_ptr(), glyphs.len() as i32, &mut extents)
+        }
 
-    //pub fn cairo_scaled_font_get_scale_matrix(scaled_font: *mut cairo_scaled_font_t, scale_matrix: *cairo_matrix_t);
+        extents
+    }
+
+    pub fn text_to_glyphs(&self, x: f64, y: f64, text: &str) -> (Vec<Glyph>, Vec<TextCluster>) {
+        // This large unsafe block is due to the FFI function returning two specially allocated
+        // (cairo_{glyph,text_cluster}_allocate) pointers that need to be copied into Vec<T>
+        // types before they're of any use to Rust code.
+
+        unsafe {
+            let mut glyphs_ptr: *mut Glyph = ptr::null_mut();
+            let mut glyph_count = 0i32;
+            let mut clusters_ptr: *mut TextCluster = ptr::null_mut();
+            let mut cluster_count = 0i32;
+            let mut cluster_flags = TextClusterFlags::None;
+
+            let status = ffi::cairo_scaled_font_text_to_glyphs(
+                self.get_ptr(),
+                x,
+                y,
+                text.to_glib_none().0,
+                text.len() as i32,
+                &mut glyphs_ptr,
+                &mut glyph_count,
+                &mut clusters_ptr,
+                &mut cluster_count,
+                &mut cluster_flags);
+
+            status.ensure_valid();
+
+            let glyph_count = glyph_count as usize;
+            let glyphs: Vec<Glyph> = {
+                let mut glyphs: Vec<Glyph> = Vec::with_capacity(glyph_count);
+
+                glyphs.set_len(glyph_count);
+                ptr::copy(glyphs_ptr, glyphs.as_mut_ptr(), glyph_count);
+
+                glyphs
+            };
+
+            let cluster_count = cluster_count as usize;
+            let clusters: Vec<TextCluster> = {
+                let mut clusters = Vec::with_capacity(cluster_count);
+
+                clusters.set_len(cluster_count);
+                ptr::copy(clusters_ptr, clusters.as_mut_ptr(), cluster_count);
+
+                clusters
+            };
+
+            ffi::cairo_glyph_free(glyphs_ptr);
+            ffi::cairo_text_cluster_free(clusters_ptr);
+
+            (glyphs, clusters)
+        }
+    }
+
+    pub fn get_font_face(&self) -> FontFace {
+        unsafe {
+            FontFace(ffi::cairo_scaled_font_get_font_face(self.get_ptr()))
+        }
+    }
+
+    pub fn get_font_options(&self) -> FontOptions {
+        let options = FontOptions::new();
+
+        unsafe {
+            ffi::cairo_scaled_font_get_font_options(self.get_ptr(), options.get_ptr())
+        }
+
+        options
+    }
+
+    pub fn get_font_matrix(&self) -> Matrix {
+        let mut matrix = Matrix::null();
+
+        unsafe {
+            ffi::cairo_scaled_font_get_font_matrix(self.get_ptr(), &mut matrix)
+        }
+
+        matrix
+    }
+
+    pub fn get_ctm(&self) -> Matrix {
+        let mut matrix = Matrix::null();
+
+        unsafe {
+            ffi::cairo_scaled_font_get_ctm(self.get_ptr(), &mut matrix)
+        }
+
+        matrix
+    }
+
+    pub fn get_scale_matrix(&self) -> Matrix {
+        let mut matrix = Matrix::null();
+
+        unsafe {
+            ffi::cairo_scaled_font_get_scale_matrix(self.get_ptr(), &mut matrix)
+        }
+
+        matrix
+    }
 
     pub fn reference(&self) -> ScaledFont {
         unsafe {


### PR DESCRIPTION
This adds the following methods to `ScaledFont`

- `extents`
- `text_extents`
- `glyph_extents`
- `text_to_glyphs`
- `get_font_face`
- `get_font_options`
- `get_font_matrix`
- `get_ctm`
- `get_scale_matrix`

and fixes three incorrect prototypes for the scaled font FFI.