### PR TITLE
impl *GlibPtr* for font types, make raw pointer fields private

### DIFF
--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -445,7 +445,7 @@ extern "C" {
 
     //CAIRO FONT OPTIONS
     pub fn cairo_font_options_create() -> *mut cairo_font_options_t;
-    pub fn cairo_font_options_copy(original: *mut cairo_font_options_t) -> *mut cairo_font_options_t;
+    pub fn cairo_font_options_copy(original: *const cairo_font_options_t) -> *mut cairo_font_options_t;
     pub fn cairo_font_options_destroy(options: *mut cairo_font_options_t);
     pub fn cairo_font_options_status(options: *mut cairo_font_options_t) -> Status;
     pub fn cairo_font_options_merge(options: *mut cairo_font_options_t, other: *mut cairo_font_options_t);

--- a/src/context.rs
+++ b/src/context.rs
@@ -622,7 +622,7 @@ impl Context {
 
     pub fn get_font_face(&self) -> FontFace {
         unsafe {
-            FontFace(ffi::cairo_get_font_face(self.0))
+            from_glib_none(ffi::cairo_get_font_face(self.0))
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -634,7 +634,7 @@ impl Context {
 
     pub fn get_scaled_font(&self) -> ScaledFont {
         unsafe {
-            ScaledFont(ffi::cairo_get_scaled_font(self.0))
+            from_glib_none(ffi::cairo_get_scaled_font(self.0))
         }
     }
 

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -149,6 +149,24 @@ impl FontOptions {
     }
 }
 
+impl<'a> ToGlibPtr<'a, *const cairo_font_options_t> for &'a FontOptions {
+    type Storage = &'a FontOptions;
+
+    #[inline]
+    fn to_glib_none(&self) -> Stash<'a, *const cairo_font_options_t, &'a FontOptions> {
+        Stash(self.0, *self)
+    }
+}
+
+impl FromGlibPtrNone<*const cairo_font_options_t> for FontOptions {
+    #[inline]
+    unsafe fn from_glib_none(ptr: *const cairo_font_options_t) -> Self {
+        let tmp = ffi::cairo_font_options_copy(ptr);
+        assert!(!tmp.is_null());
+        FontOptions(tmp)
+    }
+}
+
 impl PartialEq for FontOptions {
     fn eq(&self, other: &FontOptions) -> bool {
         unsafe {

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -161,9 +161,11 @@ impl<'a> ToGlibPtr<'a, *const cairo_font_options_t> for &'a FontOptions {
 impl FromGlibPtrNone<*const cairo_font_options_t> for FontOptions {
     #[inline]
     unsafe fn from_glib_none(ptr: *const cairo_font_options_t) -> Self {
-        let tmp = ffi::cairo_font_options_copy(ptr);
-        assert!(!tmp.is_null());
-        FontOptions(tmp)
+        let ptr = ffi::cairo_font_options_copy(ptr);
+        assert!(!ptr.is_null());
+        let tmp = FontOptions(ptr);
+        tmp.ensure_status();
+        tmp
     }
 }
 
@@ -171,7 +173,9 @@ impl FromGlibPtrFull<*mut cairo_font_options_t> for FontOptions {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut cairo_font_options_t) -> Self {
         assert!(!ptr.is_null());
-        FontOptions(ptr)
+        let tmp = FontOptions(ptr);
+        tmp.ensure_status();
+        tmp
     }
 }
 
@@ -274,9 +278,11 @@ impl<'a> ToGlibPtr<'a, *const cairo_font_face_t> for &'a FontFace {
 impl FromGlibPtrNone<*mut cairo_font_face_t> for FontFace {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut cairo_font_face_t) -> Self {
-        let tmp = ffi::cairo_font_face_reference(ptr);
-        assert!(!tmp.is_null());
-        FontFace(tmp)
+        let ptr = ffi::cairo_font_face_reference(ptr);
+        assert!(!ptr.is_null());
+        let tmp = FontFace(ptr);
+        tmp.ensure_status();
+        tmp
     }
 }
 
@@ -284,7 +290,9 @@ impl FromGlibPtrFull<*mut cairo_font_face_t> for FontFace {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut cairo_font_face_t) -> Self {
         assert!(!ptr.is_null());
-        FontFace(ptr)
+        let tmp = FontFace(ptr);
+        tmp.ensure_status();
+        tmp
     }
 }
 
@@ -500,9 +508,11 @@ impl<'a> ToGlibPtr<'a, *const cairo_scaled_font_t> for &'a ScaledFont {
 impl FromGlibPtrNone<*mut cairo_scaled_font_t> for ScaledFont {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut cairo_scaled_font_t) -> Self {
-        let tmp = ffi::cairo_scaled_font_reference(ptr);
-        assert!(!tmp.is_null());
-        ScaledFont(tmp)
+        let ptr = ffi::cairo_scaled_font_reference(ptr);
+        assert!(!ptr.is_null());
+        let tmp = ScaledFont(ptr);
+        tmp.ensure_status();
+        tmp
     }
 }
 
@@ -510,7 +520,9 @@ impl FromGlibPtrFull<*mut cairo_scaled_font_t> for ScaledFont {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut cairo_scaled_font_t) -> Self {
         assert!(!ptr.is_null());
-        ScaledFont(ptr)
+        let tmp = ScaledFont(ptr);
+        tmp.ensure_status();
+        tmp
     }
 }
 

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -167,6 +167,14 @@ impl FromGlibPtrNone<*const cairo_font_options_t> for FontOptions {
     }
 }
 
+impl FromGlibPtrFull<*mut cairo_font_options_t> for FontOptions {
+    #[inline]
+    unsafe fn from_glib_full(ptr: *mut cairo_font_options_t) -> Self {
+        assert!(!ptr.is_null());
+        FontOptions(ptr)
+    }
+}
+
 impl PartialEq for FontOptions {
     fn eq(&self, other: &FontOptions) -> bool {
         unsafe {
@@ -269,6 +277,14 @@ impl FromGlibPtrNone<*mut cairo_font_face_t> for FontFace {
         let tmp = ffi::cairo_font_face_reference(ptr);
         assert!(!tmp.is_null());
         FontFace(tmp)
+    }
+}
+
+impl FromGlibPtrFull<*mut cairo_font_face_t> for FontFace {
+    #[inline]
+    unsafe fn from_glib_full(ptr: *mut cairo_font_face_t) -> Self {
+        assert!(!ptr.is_null());
+        FontFace(ptr)
     }
 }
 

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -254,11 +254,11 @@ impl FontFace {
     }
 }
 
-impl<'a> ToGlibPtr<'a, *mut cairo_font_face_t> for &'a FontFace {
+impl<'a> ToGlibPtr<'a, *const cairo_font_face_t> for &'a FontFace {
     type Storage = &'a FontFace;
 
     #[inline]
-    fn to_glib_none(&self) -> Stash<'a, *mut cairo_font_face_t, &'a FontFace> {
+    fn to_glib_none(&self) -> Stash<'a, *const cairo_font_face_t, &'a FontFace> {
         Stash(self.0, *self)
     }
 }

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -191,7 +191,7 @@ impl Drop for FontOptions {
     }
 }
 
-pub struct FontFace(pub *mut cairo_font_face_t);
+pub struct FontFace(*mut cairo_font_face_t);
 
 impl FontFace {
     #[doc(hidden)]

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -254,6 +254,24 @@ impl FontFace {
     }
 }
 
+impl<'a> ToGlibPtr<'a, *mut cairo_font_face_t> for &'a FontFace {
+    type Storage = &'a FontFace;
+
+    #[inline]
+    fn to_glib_none(&self) -> Stash<'a, *mut cairo_font_face_t, &'a FontFace> {
+        Stash(self.0, *self)
+    }
+}
+
+impl FromGlibPtrNone<*mut cairo_font_face_t> for FontFace {
+    #[inline]
+    unsafe fn from_glib_none(ptr: *mut cairo_font_face_t) -> Self {
+        let tmp = ffi::cairo_font_face_reference(ptr);
+        assert!(!tmp.is_null());
+        FontFace(tmp)
+    }
+}
+
 impl Drop for FontFace {
     fn drop(&mut self) {
         unsafe {

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -296,7 +296,7 @@ impl Drop for FontFace {
     }
 }
 
-pub struct ScaledFont(pub *mut cairo_scaled_font_t);
+pub struct ScaledFont(*mut cairo_scaled_font_t);
 
 impl ScaledFont {
     #[doc(hidden)]
@@ -485,6 +485,32 @@ impl ScaledFont {
         unsafe {
             ScaledFont(ffi::cairo_scaled_font_reference(self.get_ptr()))
         }
+    }
+}
+
+impl<'a> ToGlibPtr<'a, *const cairo_scaled_font_t> for &'a ScaledFont {
+    type Storage = &'a ScaledFont;
+
+    #[inline]
+    fn to_glib_none(&self) -> Stash<'a, *const cairo_scaled_font_t, &'a ScaledFont> {
+        Stash(self.0, *self)
+    }
+}
+
+impl FromGlibPtrNone<*mut cairo_scaled_font_t> for ScaledFont {
+    #[inline]
+    unsafe fn from_glib_none(ptr: *mut cairo_scaled_font_t) -> Self {
+        let tmp = ffi::cairo_scaled_font_reference(ptr);
+        assert!(!tmp.is_null());
+        ScaledFont(tmp)
+    }
+}
+
+impl FromGlibPtrFull<*mut cairo_scaled_font_t> for ScaledFont {
+    #[inline]
+    unsafe fn from_glib_full(ptr: *mut cairo_scaled_font_t) -> Self {
+        assert!(!ptr.is_null());
+        ScaledFont(ptr)
     }
 }
 


### PR DESCRIPTION
I was unable to test this using pangocairo, because no matter [what I tried](https://github.com/RazrFalcon/pangocairo-rs/compare/master...johncf:cairo-fuk), I simply could not get the [`[replace]`](https://github.com/johncf/pangocairo-rs/blob/cairo-fuk/Cargo.toml#L33-L35) to work. It keeps showing `package replacement is not used` for both `cairo-rs` and `cairo-sys-rs`. May be I'm doing something wrong...

Fixes #119