### PR TITLE
Make glib dependency optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 script:
   - rustc --version
   - cargo test --features "png embed-lgpl-docs"
-  - cargo test --no-default-features
+  - cargo test --no-default-features --features "png" 
   # catch any sneaked in lgpl docs
   - cargo build --features purge-lgpl-docs
   - git diff -R --exit-code

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
 script:
   - rustc --version
   - cargo test --features "png embed-lgpl-docs"
+  - cargo test --no-default-features
   # catch any sneaked in lgpl docs
   - cargo build --features purge-lgpl-docs
   - git diff -R --exit-code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ png = ["cairo-sys-rs/png"]
 xcb = ["cairo-sys-rs/xcb"]
 purge-lgpl-docs = ["gtk-rs-lgpl-docs"]
 v1_12 = ["cairo-sys-rs/v1_12"]
+default = ["glib"]
 
 [build-dependencies.gtk-rs-lgpl-docs]
 git = "https://github.com/gtk-rs/lgpl-docs"
@@ -34,6 +35,7 @@ version = "0.3.2"
 [dependencies.glib]
 git = "https://github.com/gtk-rs/glib"
 version = "0.1.1"
+optional = true
 
 [dependencies]
 libc = "0.2"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ install:
   - pacman --noconfirm -S mingw-w64-%ARCH%-gtk3
 
 build_script:
+  - cargo test --no-default-features --features "png"
   - mkdir .cargo
   - echo paths = ["."] > .cargo\config
   - git clone -q --depth 50 -b pending https://github.com/gtk-rs/examples _examples

--- a/src/context.rs
+++ b/src/context.rs
@@ -77,7 +77,7 @@ impl AsRef<Context> for Context {
 
 impl Clone for Context {
     fn clone(&self) -> Context {
-        unsafe { Self::from_raw_none(self.0) }
+        unsafe { Self::from_raw_none(self.to_raw_none()) }
     }
 }
 
@@ -99,6 +99,11 @@ impl Context {
     unsafe fn from_raw_full(ptr: *mut ffi::cairo_t) -> Context {
         assert!(!ptr.is_null());
         Context(ptr)
+    }
+
+    #[doc(hidden)]
+    pub fn to_raw_none(&self) -> *mut ffi::cairo_t {
+        self.0
     }
 
     pub fn ensure_status(&self) {

--- a/src/font/font_face.rs
+++ b/src/font/font_face.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "glib")]
 use glib::translate::*;
+use libc::c_char;
 use ffi;
 use std::ffi::{CString,CStr};
 
@@ -70,11 +71,10 @@ impl FontFace {
     }
 
     pub fn toy_get_family(&self) -> Option<String> {
-        unsafe {
-            let family_name = ffi::cairo_toy_font_face_get_family(self.to_raw_none());
-            if family_name.is_null() { None }
-            else { Some(String::from_utf8_lossy(CStr::from_ptr(family_name).to_bytes()).into_owned()) }
-        }
+        let family_name = unsafe {
+            ffi::cairo_toy_font_face_get_family(self.to_raw_none())
+        };
+        to_optional_string(family_name)
     }
 
     pub fn toy_get_slant(&self) -> FontSlant {
@@ -108,3 +108,12 @@ impl FontFace {
         }
     }
 }
+
+fn to_optional_string(str:*const c_char) -> Option<String> {
+    if str.is_null() { None }
+    else {
+        let str = unsafe { CStr::from_ptr(str).to_bytes() };
+        Some(String::from_utf8_lossy(str).into_owned())
+    }
+}
+

--- a/src/font/font_face.rs
+++ b/src/font/font_face.rs
@@ -2,7 +2,7 @@
 use glib::translate::*;
 use libc::c_char;
 use ffi;
-use std::ffi::{CString,CStr};
+use std::ffi::{CString, CStr};
 
 use ffi::enums::{
     FontType,
@@ -71,10 +71,9 @@ impl FontFace {
     }
 
     pub fn toy_get_family(&self) -> Option<String> {
-        let family_name = unsafe {
-            ffi::cairo_toy_font_face_get_family(self.to_raw_none())
-        };
-        to_optional_string(family_name)
+        unsafe {    
+            to_optional_string(ffi::cairo_toy_font_face_get_family(self.to_raw_none()))
+        }
     }
 
     pub fn toy_get_slant(&self) -> FontSlant {
@@ -109,11 +108,11 @@ impl FontFace {
     }
 }
 
-fn to_optional_string(str:*const c_char) -> Option<String> {
-    if str.is_null() { None }
-    else {
-        let str = unsafe { CStr::from_ptr(str).to_bytes() };
-        Some(String::from_utf8_lossy(str).into_owned())
+unsafe fn to_optional_string(str: *const c_char) -> Option<String> {
+    if str.is_null() { 
+        None
+    } else {
+        Some(String::from_utf8_lossy(CStr::from_ptr(str).to_bytes()).into_owned())
     }
 }
 

--- a/src/font/font_options.rs
+++ b/src/font/font_options.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "glib")]
 use glib::translate::*;
 use std::cmp::PartialEq;
 use ffi;
@@ -9,6 +10,7 @@ use ffi::enums::{
     HintMetrics,
 };
 
+#[cfg(feature = "glib")]
 glib_wrapper! {
     pub struct FontOptions(Boxed<ffi::cairo_font_options_t>);
 
@@ -23,79 +25,107 @@ glib_wrapper! {
     }
 }
 
+#[cfg(not(feature = "glib"))]
+pub struct FontOptions(*mut ffi::cairo_font_options_t);
+
 impl FontOptions {
     pub fn new() -> FontOptions {
         let font_options: FontOptions = unsafe {
-            from_glib_full(ffi::cairo_font_options_create())
+            FontOptions::from_raw_full(ffi::cairo_font_options_create())
         };
         font_options.ensure_status();
         font_options
     }
 
+    #[cfg(feature = "glib")]
+    #[doc(hidden)]
+    pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_font_options_t) -> FontOptions {
+        from_glib_full(ptr)
+    }
+
+    #[cfg(not(feature = "glib"))]
+    #[doc(hidden)]
+    pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_font_options_t) -> FontOptions {
+        assert!(!ptr.is_null());
+        FontOptions(ptr)
+    }
+
+    #[cfg(feature = "glib")]
+    #[doc(hidden)]
+    pub fn to_raw_none(&self) -> *mut ffi::cairo_font_options_t {
+        mut_override(self.to_glib_none().0)
+    }
+
+    #[cfg(not(feature = "glib"))]
+    #[doc(hidden)]
+    pub fn to_raw_none(&self) -> *mut ffi::cairo_font_options_t {
+        self.0
+    }
+
     pub fn ensure_status(&self) {
         let status = unsafe {
-            ffi::cairo_font_options_status(mut_override(self.to_glib_none().0))
+            ffi::cairo_font_options_status(self.to_raw_none())
         };
         status.ensure_valid()
     }
 
     pub fn merge(&mut self, other: &FontOptions) {
         unsafe {
-            ffi::cairo_font_options_merge(self.to_glib_none_mut().0, other.to_glib_none().0)
+            ffi::cairo_font_options_merge(self.to_raw_none(), other.to_raw_none())
         }
     }
 
     pub fn hash(&self) -> u64{
         unsafe {
-            ffi::cairo_font_options_hash(self.to_glib_none().0) as u64
+            ffi::cairo_font_options_hash(self.to_raw_none()) as u64
         }
     }
 
     pub fn set_antialias(&mut self, antialias: Antialias) {
         unsafe {
-            ffi::cairo_font_options_set_antialias(self.to_glib_none_mut().0, antialias)
+            ffi::cairo_font_options_set_antialias(self.to_raw_none(), antialias)
         }
     }
 
     pub fn get_antialias(&self) -> Antialias {
         unsafe {
-            ffi::cairo_font_options_get_antialias(self.to_glib_none().0)
+            ffi::cairo_font_options_get_antialias(self.to_raw_none())
         }
     }
 
     pub fn set_subpixel_order(&mut self, order: SubpixelOrder) {
         unsafe {
-            ffi::cairo_font_options_set_subpixel_order(self.to_glib_none_mut().0, order)
+            ffi::cairo_font_options_set_subpixel_order(self.to_raw_none(), order)
         }
     }
 
     pub fn get_subpixel_order(&self) -> SubpixelOrder {
         unsafe {
-            ffi::cairo_font_options_get_subpixel_order(self.to_glib_none().0)
+            ffi::cairo_font_options_get_subpixel_order(self.to_raw_none())
         }
     }
 
     pub fn set_hint_style(&mut self, hint_style: HintStyle) {
         unsafe {
-            ffi::cairo_font_options_set_hint_style(self.to_glib_none_mut().0, hint_style)
+            ffi::cairo_font_options_set_hint_style(self.to_raw_none(), hint_style)
         }
     }
 
     pub fn get_hint_style(&self) -> HintStyle {
         unsafe {
-            ffi::cairo_font_options_get_hint_style(self.to_glib_none().0)
+            ffi::cairo_font_options_get_hint_style(self.to_raw_none())
         }
     }
 
     pub fn set_hint_metrics(&mut self, hint_metrics: HintMetrics) {
         unsafe {
-            ffi::cairo_font_options_set_hint_metrics(self.to_glib_none_mut().0, hint_metrics)
+            ffi::cairo_font_options_set_hint_metrics(self.to_raw_none(), hint_metrics)
         }
     }
 
     pub fn get_hint_metrics(&self) -> HintMetrics {
         unsafe {
-            ffi::cairo_font_options_get_hint_metrics(self.to_glib_none().0)
+            ffi::cairo_font_options_get_hint_metrics(self.to_raw_none())
         }
     }
 }
@@ -103,7 +133,7 @@ impl FontOptions {
 impl PartialEq for FontOptions {
     fn eq(&self, other: &FontOptions) -> bool {
         unsafe {
-            ffi::cairo_font_options_equal(self.to_glib_none().0, other.to_glib_none().0).as_bool()
+            ffi::cairo_font_options_equal(self.to_raw_none(), other.to_raw_none()).as_bool()
         }
     }
 }

--- a/src/font/scaled_font.rs
+++ b/src/font/scaled_font.rs
@@ -127,9 +127,9 @@ impl ScaledFont {
             y_advance: 0.0,
         };
 
-        let text_to_convert = CString::new(text).unwrap();
+        let text = CString::new(text).unwrap();
         unsafe {
-            ffi::cairo_scaled_font_text_extents(self.to_raw_none(), text_to_convert.as_ptr(), &mut extents)
+            ffi::cairo_scaled_font_text_extents(self.to_raw_none(), text.as_ptr(), &mut extents)
         }
 
         extents
@@ -163,15 +163,15 @@ impl ScaledFont {
             let mut clusters_ptr: *mut TextCluster = ptr::null_mut();
             let mut cluster_count = 0i32;
             let mut cluster_flags = TextClusterFlags::None;
-
-            let text_to_convert = CString::new(text).unwrap();
+            let text_length = text.len() as i32;
+            let text = CString::new(text).unwrap();
 
             let status = ffi::cairo_scaled_font_text_to_glyphs(
                 self.to_raw_none(),
                 x,
                 y,
-                text_to_convert.as_ptr(),
-                text.len() as i32,
+                text.as_ptr(),
+                text_length,
                 &mut glyphs_ptr,
                 &mut glyph_count,
                 &mut clusters_ptr,

--- a/src/font/scaled_font.rs
+++ b/src/font/scaled_font.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "glib")]
 use glib::translate::*;
 use std::ptr;
 use ffi;
+use std::ffi::CString;
 
 use ffi::enums::{
     FontType,
@@ -19,6 +21,7 @@ use ffi::{
 
 use super::{FontFace, FontOptions};
 
+#[cfg(feature = "glib")]
 glib_wrapper! {
     pub struct ScaledFont(Shared<ffi::cairo_scaled_font_t>);
 
@@ -28,31 +31,73 @@ glib_wrapper! {
     }
 }
 
+#[cfg(not(feature = "glib"))]
+pub struct ScaledFont(*mut ffi::cairo_scaled_font_t);
+
 impl ScaledFont {
     pub fn new(font_face: FontFace, font_matrix: &Matrix, ctm: &Matrix, options: &FontOptions) -> ScaledFont {
         let scaled_font: ScaledFont = unsafe {
-            from_glib_full(ffi::cairo_scaled_font_create(font_face.to_glib_none().0, font_matrix, ctm, options.to_glib_none().0))
+            ScaledFont::from_raw_full(ffi::cairo_scaled_font_create(font_face.to_raw_none(), font_matrix, ctm, options.to_raw_none()))
         };
         scaled_font.ensure_status();
         scaled_font
     }
 
+    #[cfg(feature = "glib")]
+    #[doc(hidden)]
+    pub fn to_raw_none(&self) -> *mut ffi::cairo_scaled_font_t {
+        self.to_glib_none().0
+    }
+
+    #[cfg(not(feature = "glib"))]
+    #[doc(hidden)]
+    pub fn to_raw_none(&self) -> *mut ffi::cairo_scaled_font_t {
+        self.0
+    }
+
+    #[cfg(not(feature = "glib"))]
+    #[doc(hidden)]
+    pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_scaled_font_t) -> ScaledFont {
+        assert!(!ptr.is_null());
+        ScaledFont(ptr)
+    }
+
+    #[cfg(feature = "glib")]
+    #[doc(hidden)]
+    pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_scaled_font_t) -> ScaledFont {
+        from_glib_full(ptr)
+    }
+
+    #[cfg(feature = "glib")]
+    #[doc(hidden)]
+    pub unsafe fn from_raw_none(ptr: *mut ffi::cairo_scaled_font_t) -> ScaledFont {
+        from_glib_none(ptr)
+    }
+
+    #[cfg(not(feature = "glib"))]
+    #[doc(hidden)]
+    pub unsafe fn from_raw_none(ptr: *mut ffi::cairo_scaled_font_t) -> ScaledFont {
+        assert!(!ptr.is_null());
+        ffi::cairo_scaled_font_reference(ptr);
+        ScaledFont(ptr)
+    }
+
     pub fn ensure_status(&self) {
         let status = unsafe {
-            ffi::cairo_scaled_font_status(self.to_glib_none().0)
+            ffi::cairo_scaled_font_status(self.to_raw_none())
         };
         status.ensure_valid()
     }
 
     pub fn get_type(&self) -> FontType {
         unsafe {
-            ffi::cairo_scaled_font_get_type(self.to_glib_none().0)
+            ffi::cairo_scaled_font_get_type(self.to_raw_none())
         }
     }
 
     pub fn get_reference_count(&self) -> usize {
         unsafe {
-            ffi::cairo_scaled_font_get_reference_count(self.to_glib_none().0) as usize
+            ffi::cairo_scaled_font_get_reference_count(self.to_raw_none()) as usize
         }
     }
 
@@ -66,7 +111,7 @@ impl ScaledFont {
         };
 
         unsafe {
-            ffi::cairo_scaled_font_extents(self.to_glib_none().0, &mut extents)
+            ffi::cairo_scaled_font_extents(self.to_raw_none(), &mut extents)
         }
 
         extents
@@ -82,8 +127,9 @@ impl ScaledFont {
             y_advance: 0.0,
         };
 
+        let text_to_convert = CString::new(text).unwrap();
         unsafe {
-            ffi::cairo_scaled_font_text_extents(self.to_glib_none().0, text.to_glib_none().0, &mut extents)
+            ffi::cairo_scaled_font_text_extents(self.to_raw_none(), text_to_convert.as_ptr(), &mut extents)
         }
 
         extents
@@ -100,7 +146,7 @@ impl ScaledFont {
         };
 
         unsafe {
-            ffi::cairo_scaled_font_glyph_extents(self.to_glib_none().0, glyphs.as_ptr(), glyphs.len() as i32, &mut extents)
+            ffi::cairo_scaled_font_glyph_extents(self.to_raw_none(), glyphs.as_ptr(), glyphs.len() as i32, &mut extents)
         }
 
         extents
@@ -118,11 +164,13 @@ impl ScaledFont {
             let mut cluster_count = 0i32;
             let mut cluster_flags = TextClusterFlags::None;
 
+            let text_to_convert = CString::new(text).unwrap();
+
             let status = ffi::cairo_scaled_font_text_to_glyphs(
-                self.to_glib_none().0,
+                self.to_raw_none(),
                 x,
                 y,
-                text.to_glib_none().0,
+                text_to_convert.as_ptr(),
                 text.len() as i32,
                 &mut glyphs_ptr,
                 &mut glyph_count,
@@ -161,15 +209,15 @@ impl ScaledFont {
 
     pub fn get_font_face(&self) -> FontFace {
         unsafe {
-            from_glib_none(ffi::cairo_scaled_font_get_font_face(self.to_glib_none().0))
+            FontFace::from_raw_none(ffi::cairo_scaled_font_get_font_face(self.to_raw_none()))
         }
     }
 
     pub fn get_font_options(&self) -> FontOptions {
-        let mut options = FontOptions::new();
+        let options = FontOptions::new();
 
         unsafe {
-            ffi::cairo_scaled_font_get_font_options(self.to_glib_none().0, options.to_glib_none_mut().0)
+            ffi::cairo_scaled_font_get_font_options(self.to_raw_none(), options.to_raw_none())
         }
 
         options
@@ -179,7 +227,7 @@ impl ScaledFont {
         let mut matrix = Matrix::null();
 
         unsafe {
-            ffi::cairo_scaled_font_get_font_matrix(self.to_glib_none().0, &mut matrix)
+            ffi::cairo_scaled_font_get_font_matrix(self.to_raw_none(), &mut matrix)
         }
 
         matrix
@@ -189,7 +237,7 @@ impl ScaledFont {
         let mut matrix = Matrix::null();
 
         unsafe {
-            ffi::cairo_scaled_font_get_ctm(self.to_glib_none().0, &mut matrix)
+            ffi::cairo_scaled_font_get_ctm(self.to_raw_none(), &mut matrix)
         }
 
         matrix
@@ -199,7 +247,7 @@ impl ScaledFont {
         let mut matrix = Matrix::null();
 
         unsafe {
-            ffi::cairo_scaled_font_get_scale_matrix(self.to_glib_none().0, &mut matrix)
+            ffi::cairo_scaled_font_get_scale_matrix(self.to_raw_none(), &mut matrix)
         }
 
         matrix

--- a/src/image_surface_png.rs
+++ b/src/image_surface_png.rs
@@ -90,5 +90,4 @@ impl ImageSurface {
             Some(err) => Err(IoError::Io(err)),
         }
     }
-
 }

--- a/src/image_surface_png.rs
+++ b/src/image_surface_png.rs
@@ -9,6 +9,7 @@ use std::thread;
 
 use libc::{c_void, c_uint};
 
+#[cfg(feature = "glib")]
 use glib::translate::*;
 use ffi;
 use ffi::enums::Status;
@@ -66,7 +67,7 @@ unsafe extern "C" fn write_func<W: Write>(closure: *mut c_void, data: *mut u8, l
 impl ImageSurface {
     pub fn create_from_png<R: Read>(stream: &mut R) -> Result<ImageSurface, IoError> {
         let mut env = ReadEnv{ reader: stream, error: None };
-        let surface: ImageSurface = unsafe { from_glib_full(ffi::cairo_image_surface_create_from_png_stream(
+        let surface: ImageSurface = unsafe { ImageSurface::from_raw_full(ffi::cairo_image_surface_create_from_png_stream(
             Some(read_func::<R>), &mut env as *mut ReadEnv<R> as *mut c_void)) };
         match env.error {
             None => match surface.as_ref().status() {   // The surface migth still be "nil" if the error occured in Cairo
@@ -79,7 +80,7 @@ impl ImageSurface {
 
     pub fn write_to_png<W: Write>(&self, stream: &mut W) -> Result<(), IoError> {
         let mut env = WriteEnv{ writer: stream, error: None };
-        let status = unsafe { ffi::cairo_surface_write_to_png_stream(self.to_glib_none().0,
+        let status = unsafe { ffi::cairo_surface_write_to_png_stream(self.to_raw_none(),
             Some(write_func::<W>), &mut env as *mut WriteEnv<W> as *mut c_void) };
         match env.error {
             None => match status {
@@ -89,4 +90,5 @@ impl ImageSurface {
             Some(err) => Err(IoError::Io(err)),
         }
     }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,11 @@
 
 extern crate cairo_sys as ffi;
 extern crate libc;
+extern crate c_vec;
+
+#[cfg(feature = "glib")]
 #[macro_use]
 extern crate glib;
-extern crate c_vec;
 
 pub use ffi::enums;
 pub use ffi::cairo_rectangle_t as Rectangle;

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -7,7 +7,6 @@
 use libc::{c_double, c_int, c_uint};
 use std::ptr;
 use std::mem::transmute;
-use glib::translate::*;
 use ffi::enums::{
     Extend,
     Filter,
@@ -269,7 +268,7 @@ pattern_type!(SurfacePattern);
 impl SurfacePattern {
     pub fn create<T: AsRef<Surface>>(surface: &T) -> SurfacePattern {
         SurfacePattern::wrap(unsafe {
-            ffi::cairo_pattern_create_for_surface(surface.as_ref().to_glib_none().0)
+            ffi::cairo_pattern_create_for_surface(surface.as_ref().to_raw_none())
         })
     }
 
@@ -277,7 +276,7 @@ impl SurfacePattern {
         unsafe {
             let mut surface_ptr: *mut cairo_surface_t = ptr::null_mut();
             ffi::cairo_pattern_get_surface(self.pointer, &mut surface_ptr).ensure_valid();
-            Surface::from_glib_none(surface_ptr)
+            Surface::from_raw_none(surface_ptr)
         }
     }
 }

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "glib")]
 use ffi;
+#[cfg(feature = "glib")]
 use glib::translate::*;
+#[cfg(feature = "glib")]
 use std::mem;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -11,6 +14,7 @@ pub struct RectangleInt {
     pub height: i32,
 }
 
+#[cfg(feature = "glib")]
 #[doc(hidden)]
 impl Uninitialized for RectangleInt {
     #[inline]
@@ -19,6 +23,7 @@ impl Uninitialized for RectangleInt {
     }
 }
 
+#[cfg(feature = "glib")]
 #[doc(hidden)]
 impl<'a> ToGlibPtr<'a, *const ffi::cairo_rectangle_int_t> for RectangleInt {
     type Storage = &'a Self;
@@ -30,6 +35,7 @@ impl<'a> ToGlibPtr<'a, *const ffi::cairo_rectangle_int_t> for RectangleInt {
     }
 }
 
+#[cfg(feature = "glib")]
 #[doc(hidden)]
 impl<'a> ToGlibPtrMut<'a, *mut ffi::cairo_rectangle_int_t> for RectangleInt {
     type Storage = &'a mut Self;
@@ -41,6 +47,7 @@ impl<'a> ToGlibPtrMut<'a, *mut ffi::cairo_rectangle_int_t> for RectangleInt {
     }
 }
 
+#[cfg(feature = "glib")]
 #[doc(hidden)]
 impl FromGlibPtrNone<*const ffi::cairo_rectangle_int_t> for RectangleInt {
     unsafe fn from_glib_none(ptr: *const ffi::cairo_rectangle_int_t) -> Self {
@@ -48,6 +55,7 @@ impl FromGlibPtrNone<*const ffi::cairo_rectangle_int_t> for RectangleInt {
     }
 }
 
+#[cfg(feature = "glib")]
 #[doc(hidden)]
 impl FromGlibPtrNone<*mut ffi::cairo_rectangle_int_t> for RectangleInt {
     unsafe fn from_glib_none(ptr: *mut ffi::cairo_rectangle_int_t) -> Self {

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -5,6 +5,7 @@
 use std::mem;
 use libc::c_void;
 
+#[cfg(feature = "glib")]
 use glib::translate::*;
 use ffi;
 use ffi::enums::{
@@ -17,12 +18,30 @@ use ffi::enums::{
 pub struct Surface(*mut ffi::cairo_surface_t);
 
 impl Surface {
+    #[doc(hidden)]
+    pub unsafe fn from_raw_none(ptr: *mut ffi::cairo_surface_t) -> Surface {
+        assert!(!ptr.is_null());
+        ffi::cairo_surface_reference(ptr);
+        Surface(ptr)
+    }
+
+    #[doc(hidden)]
+    pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_surface_t) -> Surface {
+        assert!(!ptr.is_null());
+        Surface(ptr)
+    }
+
+    #[doc(hidden)]
+    pub fn to_raw_none(&self) -> *mut ffi::cairo_surface_t {
+        self.0
+    }
+
     pub fn status(&self) -> Status {
-        unsafe { ffi::cairo_surface_status(self.to_glib_none().0) }
+        unsafe { ffi::cairo_surface_status(self.0) }
     }
 
     pub fn create_similar(&self, content: Content, width: i32, height: i32) -> Surface {
-        unsafe { from_glib_full(ffi::cairo_surface_create_similar(self.to_glib_none().0, content, width, height)) }
+        unsafe { Self::from_raw_full(ffi::cairo_surface_create_similar(self.0, content, width, height)) }
     }
 
     #[cfg(macos)]
@@ -41,29 +60,29 @@ impl Surface {
     }
 }
 
+#[cfg(feature = "glib")]
 impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Surface {
     type Storage = &'a Surface;
 
     #[inline]
     fn to_glib_none(&'a self) -> Stash<'a, *mut ffi::cairo_surface_t, Self> {
-        Stash(self.0, self)
+        Stash(self.to_raw_none(), self)
     }
 }
 
+#[cfg(feature = "glib")]
 impl FromGlibPtrNone<*mut ffi::cairo_surface_t> for Surface {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut ffi::cairo_surface_t) -> Surface {
-        assert!(!ptr.is_null());
-        ffi::cairo_surface_reference(ptr);
-        Surface(ptr)
+        Self::from_raw_none(ptr)
     }
 }
 
+#[cfg(feature = "glib")]
 impl FromGlibPtrFull<*mut ffi::cairo_surface_t> for Surface {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut ffi::cairo_surface_t) -> Surface {
-        assert!(!ptr.is_null());
-        Surface(ptr)
+        Self::from_raw_full(ptr)
     }
 }
 
@@ -75,7 +94,7 @@ impl AsRef<Surface> for Surface {
 
 impl Clone for Surface {
     fn clone(&self) -> Surface {
-        unsafe { from_glib_none(self.to_glib_none().0) }
+        unsafe { Self::from_raw_none(self.0) }
     }
 }
 

--- a/src/win32_surface.rs
+++ b/src/win32_surface.rs
@@ -29,12 +29,6 @@ impl Win32Surface {
         Self::from(Surface::from_raw_full(ptr)).unwrap()
     }
 
-    #[doc(hidden)]
-    unsafe fn from_raw_none(ptr: *mut ffi::cairo_surface_t) -> Win32Surface {
-        assert!(!ptr.is_null());
-        Win32Surface(Surface::from_raw_none(ptr))
-    }
-
     pub fn create(hdc: winapi::HDC) -> Win32Surface {
         unsafe { Self::from_raw_full(ffi::cairo_win32_surface_create(hdc)) }
     }
@@ -101,6 +95,6 @@ impl Deref for Win32Surface {
 
 impl Clone for Win32Surface {
     fn clone(&self) -> Win32Surface {
-        unsafe { Self::from_raw_none(self.to_raw_none()) }
+        Win32Surface(self.0.clone())
     }
 }

--- a/src/win32_surface.rs
+++ b/src/win32_surface.rs
@@ -6,6 +6,7 @@ extern crate winapi;
 
 use std::ops::Deref;
 
+#[cfg(feature = "glib")]
 use glib::translate::*;
 use ffi;
 use ffi::enums::{Format, SurfaceType};
@@ -23,12 +24,23 @@ impl Win32Surface {
         }
     }
 
+    #[doc(hidden)]
+    pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_surface_t) -> Win32Surface {
+        Self::from(Surface::from_raw_full(ptr)).unwrap()
+    }
+
+    #[doc(hidden)]
+    unsafe fn from_raw_none(ptr: *mut ffi::cairo_surface_t) -> Win32Surface {
+        assert!(!ptr.is_null());
+        Win32Surface(Surface::from_raw_none(ptr))
+    }
+
     pub fn create(hdc: winapi::HDC) -> Win32Surface {
-        unsafe { from_glib_full(ffi::cairo_win32_surface_create(hdc)) }
+        unsafe { Self::from_raw_full(ffi::cairo_win32_surface_create(hdc)) }
     }
 
     pub fn create_with_dib(format: Format, width: i32, height: i32) -> Win32Surface {
-        unsafe { from_glib_full(ffi::cairo_win32_surface_create_with_dib(format, width, height)) }
+        unsafe { Self::from_raw_full(ffi::cairo_win32_surface_create_with_dib(format, width, height)) }
     }
 
     pub fn create_with_ddb(hdc: winapi::HDC,
@@ -37,15 +49,16 @@ impl Win32Surface {
                            height: i32)
                            -> Win32Surface {
         unsafe {
-            from_glib_full(ffi::cairo_win32_surface_create_with_ddb(hdc, format, width, height))
+            Self::from_raw_full(ffi::cairo_win32_surface_create_with_ddb(hdc, format, width, height))
         }
     }
 
     pub fn printing_surface_create(hdc: winapi::HDC) -> Win32Surface {
-        unsafe { from_glib_full(ffi::cairo_win32_printing_surface_create(hdc)) }
+        unsafe { Self::from_raw_full(ffi::cairo_win32_printing_surface_create(hdc)) }
     }
 }
 
+#[cfg(feature = "glib")]
 impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Win32Surface {
     type Storage = &'a Surface;
 
@@ -56,6 +69,7 @@ impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Win32Surface {
     }
 }
 
+#[cfg(feature = "glib")]
 impl FromGlibPtrNone<*mut ffi::cairo_surface_t> for Win32Surface {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut ffi::cairo_surface_t) -> Win32Surface {
@@ -63,6 +77,7 @@ impl FromGlibPtrNone<*mut ffi::cairo_surface_t> for Win32Surface {
     }
 }
 
+#[cfg(feature = "glib")]
 impl FromGlibPtrFull<*mut ffi::cairo_surface_t> for Win32Surface {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut ffi::cairo_surface_t) -> Win32Surface {
@@ -86,6 +101,6 @@ impl Deref for Win32Surface {
 
 impl Clone for Win32Surface {
     fn clone(&self) -> Win32Surface {
-        unsafe { from_glib_none(self.to_glib_none().0) }
+        unsafe { Self::from_raw_none(self.to_raw_none()) }
     }
 }


### PR DESCRIPTION
The Cairo bindings used the glib::translate traits to handle internal reference counting discipline. However, these are not actually required, and should be possible to use Cairo without a dependency on glib. This patch makes the dependency optional, and changes the implementation to not use the glib traits internally.

The glib feature is a default feature, so this should not cause problems for gtk users of cairo-rs, but does allow for use of Cairo from Rust in projects that don't want to also depend on glib.