### PR TITLE
Update for non-generic pointer array impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ png = ["cairo-sys-rs/png"]
 xcb = ["cairo-sys-rs/xcb"]
 purge-lgpl-docs = ["gtk-rs-lgpl-docs"]
 v1_12 = ["cairo-sys-rs/v1_12"]
-default = ["glib"]
+use_glib = ["glib", "glib-sys"]
+default = ["use_glib"]
 
 [build-dependencies.gtk-rs-lgpl-docs]
 git = "https://github.com/gtk-rs/lgpl-docs"
@@ -35,6 +36,11 @@ version = "0.3.4"
 [dependencies.glib]
 git = "https://github.com/gtk-rs/glib"
 version = "0.1.3"
+optional = true
+
+[dependencies.glib-sys]
+git = "https://github.com/gtk-rs/sys"
+version = "0.3.4"
 optional = true
 
 [dependencies]

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,7 +2,7 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 use glib::translate::*;
 use c_vec::CVec;
 use std::mem::transmute;
@@ -43,7 +43,7 @@ impl Drop for RectangleVec {
 
 pub struct Context(*mut cairo_t);
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl<'a> ToGlibPtr<'a, *mut ffi::cairo_t> for &'a Context {
     type Storage = &'a Context;
 
@@ -53,7 +53,7 @@ impl<'a> ToGlibPtr<'a, *mut ffi::cairo_t> for &'a Context {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrNone<*mut ffi::cairo_t> for Context {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut ffi::cairo_t) -> Context {
@@ -61,7 +61,7 @@ impl FromGlibPtrNone<*mut ffi::cairo_t> for Context {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrFull<*mut ffi::cairo_t> for Context {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut ffi::cairo_t) -> Context {

--- a/src/font/font_face.rs
+++ b/src/font/font_face.rs
@@ -1,5 +1,11 @@
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 use glib::translate::*;
+#[cfg(feature = "use_glib")]
+use glib_ffi;
+#[cfg(feature = "use_glib")]
+use std::ptr;
+#[cfg(feature = "use_glib")]
+use std::mem;
 use libc::c_char;
 use ffi;
 use std::ffi::{CString, CStr};
@@ -10,7 +16,7 @@ use ffi::enums::{
     FontSlant,
 };
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 glib_wrapper! {
     pub struct FontFace(Shared<ffi::cairo_font_face_t>);
 
@@ -20,7 +26,7 @@ glib_wrapper! {
     }
 }
 
-#[cfg(not(feature = "glib"))]
+#[cfg(not(feature = "use_glib"))]
 pub struct FontFace(*mut ffi::cairo_font_face_t);
 
 impl FontFace {
@@ -32,39 +38,39 @@ impl FontFace {
         font_face
     }
 
-    #[cfg(feature = "glib")]
+    #[cfg(feature = "use_glib")]
     #[doc(hidden)]
     pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_font_face_t) -> FontFace {
         from_glib_full(ptr)
     }
 
-    #[cfg(not(feature = "glib"))]
+    #[cfg(not(feature = "use_glib"))]
     #[doc(hidden)]
     pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_font_face_t) -> FontFace {
         assert!(!ptr.is_null());
         FontFace(ptr)
     }
 
-    #[cfg(feature = "glib")]
+    #[cfg(feature = "use_glib")]
     #[doc(hidden)]
     pub unsafe fn from_raw_none(ptr: *mut ffi::cairo_font_face_t) -> FontFace {
         from_glib_none(ptr)
     }
 
-    #[cfg(not(feature = "glib"))]
+    #[cfg(not(feature = "use_glib"))]
     #[doc(hidden)]
     pub unsafe fn from_raw_none(ptr: *mut ffi::cairo_font_face_t) -> FontFace {
         assert!(!ptr.is_null());
         FontFace(ptr)
     }
 
-    #[cfg(feature = "glib")]
+    #[cfg(feature = "use_glib")]
     #[doc(hidden)]
     pub fn to_raw_none(&self) -> *mut ffi::cairo_font_face_t {
         self.to_glib_none().0
     }
 
-    #[cfg(not(feature = "glib"))]
+    #[cfg(not(feature = "use_glib"))]
     #[doc(hidden)]
     pub fn to_raw_none(&self) -> *mut ffi::cairo_font_face_t {
         self.0

--- a/src/font/font_options.rs
+++ b/src/font/font_options.rs
@@ -1,5 +1,11 @@
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 use glib::translate::*;
+#[cfg(feature = "use_glib")]
+use glib_ffi;
+#[cfg(feature = "use_glib")]
+use std::ptr;
+#[cfg(feature = "use_glib")]
+use std::mem;
 use std::cmp::PartialEq;
 use ffi;
 
@@ -10,7 +16,7 @@ use ffi::enums::{
     HintMetrics,
 };
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 glib_wrapper! {
     pub struct FontOptions(Boxed<ffi::cairo_font_options_t>);
 
@@ -25,7 +31,7 @@ glib_wrapper! {
     }
 }
 
-#[cfg(not(feature = "glib"))]
+#[cfg(not(feature = "use_glib"))]
 pub struct FontOptions(*mut ffi::cairo_font_options_t);
 
 impl FontOptions {
@@ -37,26 +43,26 @@ impl FontOptions {
         font_options
     }
 
-    #[cfg(feature = "glib")]
+    #[cfg(feature = "use_glib")]
     #[doc(hidden)]
     pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_font_options_t) -> FontOptions {
         from_glib_full(ptr)
     }
 
-    #[cfg(not(feature = "glib"))]
+    #[cfg(not(feature = "use_glib"))]
     #[doc(hidden)]
     pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_font_options_t) -> FontOptions {
         assert!(!ptr.is_null());
         FontOptions(ptr)
     }
 
-    #[cfg(feature = "glib")]
+    #[cfg(feature = "use_glib")]
     #[doc(hidden)]
     pub fn to_raw_none(&self) -> *mut ffi::cairo_font_options_t {
         mut_override(self.to_glib_none().0)
     }
 
-    #[cfg(not(feature = "glib"))]
+    #[cfg(not(feature = "use_glib"))]
     #[doc(hidden)]
     pub fn to_raw_none(&self) -> *mut ffi::cairo_font_options_t {
         self.0

--- a/src/font/scaled_font.rs
+++ b/src/font/scaled_font.rs
@@ -1,6 +1,10 @@
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 use glib::translate::*;
+#[cfg(feature = "use_glib")]
+use glib_ffi;
 use std::ptr;
+#[cfg(feature = "use_glib")]
+use std::mem;
 use ffi;
 use std::ffi::CString;
 
@@ -21,7 +25,7 @@ use ffi::{
 
 use super::{FontFace, FontOptions};
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 glib_wrapper! {
     pub struct ScaledFont(Shared<ffi::cairo_scaled_font_t>);
 
@@ -31,7 +35,7 @@ glib_wrapper! {
     }
 }
 
-#[cfg(not(feature = "glib"))]
+#[cfg(not(feature = "use_glib"))]
 pub struct ScaledFont(*mut ffi::cairo_scaled_font_t);
 
 impl ScaledFont {
@@ -43,38 +47,38 @@ impl ScaledFont {
         scaled_font
     }
 
-    #[cfg(feature = "glib")]
+    #[cfg(feature = "use_glib")]
     #[doc(hidden)]
     pub fn to_raw_none(&self) -> *mut ffi::cairo_scaled_font_t {
         self.to_glib_none().0
     }
 
-    #[cfg(not(feature = "glib"))]
+    #[cfg(not(feature = "use_glib"))]
     #[doc(hidden)]
     pub fn to_raw_none(&self) -> *mut ffi::cairo_scaled_font_t {
         self.0
     }
 
-    #[cfg(not(feature = "glib"))]
+    #[cfg(not(feature = "use_glib"))]
     #[doc(hidden)]
     pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_scaled_font_t) -> ScaledFont {
         assert!(!ptr.is_null());
         ScaledFont(ptr)
     }
 
-    #[cfg(feature = "glib")]
+    #[cfg(feature = "use_glib")]
     #[doc(hidden)]
     pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_scaled_font_t) -> ScaledFont {
         from_glib_full(ptr)
     }
 
-    #[cfg(feature = "glib")]
+    #[cfg(feature = "use_glib")]
     #[doc(hidden)]
     pub unsafe fn from_raw_none(ptr: *mut ffi::cairo_scaled_font_t) -> ScaledFont {
         from_glib_none(ptr)
     }
 
-    #[cfg(not(feature = "glib"))]
+    #[cfg(not(feature = "use_glib"))]
     #[doc(hidden)]
     pub unsafe fn from_raw_none(ptr: *mut ffi::cairo_scaled_font_t) -> ScaledFont {
         assert!(!ptr.is_null());

--- a/src/image_surface.rs
+++ b/src/image_surface.rs
@@ -5,7 +5,7 @@
 use std::ops::{Deref, DerefMut};
 use std::slice;
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 use glib::translate::*;
 use ffi;
 use ffi::enums::{
@@ -88,7 +88,7 @@ impl ImageSurface {
 
 static IMAGE_SURFACE_DATA: () = ();
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for ImageSurface {
     type Storage = &'a Surface;
 
@@ -99,7 +99,7 @@ impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for ImageSurface {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrNone<*mut ffi::cairo_surface_t> for ImageSurface {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut ffi::cairo_surface_t) -> ImageSurface {
@@ -107,7 +107,7 @@ impl FromGlibPtrNone<*mut ffi::cairo_surface_t> for ImageSurface {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrFull<*mut ffi::cairo_surface_t> for ImageSurface {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut ffi::cairo_surface_t) -> ImageSurface {

--- a/src/image_surface_png.rs
+++ b/src/image_surface_png.rs
@@ -9,7 +9,7 @@ use std::thread;
 
 use libc::{c_void, c_uint};
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 use glib::translate::*;
 use ffi;
 use ffi::enums::Status;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,12 @@ extern crate cairo_sys as ffi;
 extern crate libc;
 extern crate c_vec;
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 #[macro_use]
 extern crate glib;
+
+#[cfg(feature = "use_glib")]
+extern crate glib_sys as glib_ffi;
 
 pub use ffi::enums;
 pub use ffi::cairo_rectangle_t as Rectangle;

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -1,7 +1,7 @@
 use ffi;
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 use glib::translate::*;
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 use std::mem;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -13,7 +13,7 @@ pub struct RectangleInt {
     pub height: i32,
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 #[doc(hidden)]
 impl Uninitialized for RectangleInt {
     #[inline]
@@ -22,7 +22,7 @@ impl Uninitialized for RectangleInt {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 #[doc(hidden)]
 impl<'a> ToGlibPtr<'a, *const ffi::cairo_rectangle_int_t> for RectangleInt {
     type Storage = &'a Self;
@@ -34,7 +34,7 @@ impl<'a> ToGlibPtr<'a, *const ffi::cairo_rectangle_int_t> for RectangleInt {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 #[doc(hidden)]
 impl<'a> ToGlibPtrMut<'a, *mut ffi::cairo_rectangle_int_t> for RectangleInt {
     type Storage = &'a mut Self;
@@ -46,7 +46,7 @@ impl<'a> ToGlibPtrMut<'a, *mut ffi::cairo_rectangle_int_t> for RectangleInt {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 #[doc(hidden)]
 impl FromGlibPtrNone<*const ffi::cairo_rectangle_int_t> for RectangleInt {
     unsafe fn from_glib_none(ptr: *const ffi::cairo_rectangle_int_t) -> Self {
@@ -54,7 +54,7 @@ impl FromGlibPtrNone<*const ffi::cairo_rectangle_int_t> for RectangleInt {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 #[doc(hidden)]
 impl FromGlibPtrNone<*mut ffi::cairo_rectangle_int_t> for RectangleInt {
     unsafe fn from_glib_none(ptr: *mut ffi::cairo_rectangle_int_t) -> Self {

--- a/src/region.rs
+++ b/src/region.rs
@@ -2,7 +2,7 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 use glib::translate::*;
 use ffi::enums::RegionOverlap;
 use RectangleInt;
@@ -13,7 +13,7 @@ use ffi::enums::Status;
 
 pub struct Region(*mut cairo_region_t);
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 #[doc(hidden)]
 impl<'a> ToGlibPtr<'a, *mut ffi::cairo_region_t> for &'a Region {
     type Storage = &'a Region;
@@ -24,7 +24,7 @@ impl<'a> ToGlibPtr<'a, *mut ffi::cairo_region_t> for &'a Region {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 #[doc(hidden)]
 impl<'a> ToGlibPtrMut<'a, *mut ffi::cairo_region_t> for Region {
     type Storage = &'a mut Self;
@@ -35,7 +35,7 @@ impl<'a> ToGlibPtrMut<'a, *mut ffi::cairo_region_t> for Region {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 #[doc(hidden)]
 impl FromGlibPtrNone<*mut ffi::cairo_region_t> for Region {
     #[inline]
@@ -44,7 +44,7 @@ impl FromGlibPtrNone<*mut ffi::cairo_region_t> for Region {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 #[doc(hidden)]
 impl FromGlibPtrFull<*mut ffi::cairo_region_t> for Region {
     #[inline]

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -10,7 +10,7 @@ use ffi::enums::Format;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use ffi::CGContextRef;
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 use glib::translate::*;
 use ffi;
 use ffi::enums::{
@@ -65,7 +65,7 @@ impl Surface {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Surface {
     type Storage = &'a Surface;
 
@@ -75,7 +75,7 @@ impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Surface {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrNone<*mut ffi::cairo_surface_t> for Surface {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut ffi::cairo_surface_t) -> Surface {
@@ -83,7 +83,7 @@ impl FromGlibPtrNone<*mut ffi::cairo_surface_t> for Surface {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrFull<*mut ffi::cairo_surface_t> for Surface {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut ffi::cairo_surface_t) -> Surface {

--- a/src/win32_surface.rs
+++ b/src/win32_surface.rs
@@ -6,7 +6,7 @@ extern crate winapi;
 
 use std::ops::Deref;
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 use glib::translate::*;
 use ffi;
 use ffi::enums::{Format, SurfaceType};
@@ -52,7 +52,7 @@ impl Win32Surface {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Win32Surface {
     type Storage = &'a Surface;
 
@@ -63,7 +63,7 @@ impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Win32Surface {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrNone<*mut ffi::cairo_surface_t> for Win32Surface {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut ffi::cairo_surface_t) -> Win32Surface {
@@ -71,7 +71,7 @@ impl FromGlibPtrNone<*mut ffi::cairo_surface_t> for Win32Surface {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrFull<*mut ffi::cairo_surface_t> for Win32Surface {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut ffi::cairo_surface_t) -> Win32Surface {

--- a/src/xcb.rs
+++ b/src/xcb.rs
@@ -2,7 +2,7 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 use glib::translate::*;
 use ffi;
 
@@ -45,7 +45,7 @@ impl XCBConnection {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl<'a> ToGlibPtr<'a, *mut ffi::xcb_connection_t> for &'a XCBConnection {
     type Storage = &'a XCBConnection;
 
@@ -55,7 +55,7 @@ impl<'a> ToGlibPtr<'a, *mut ffi::xcb_connection_t> for &'a XCBConnection {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrNone<*mut ffi::xcb_connection_t> for XCBConnection {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut ffi::xcb_connection_t) -> XCBConnection {
@@ -63,7 +63,7 @@ impl FromGlibPtrNone<*mut ffi::xcb_connection_t> for XCBConnection {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrFull<*mut ffi::xcb_connection_t> for XCBConnection {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut ffi::xcb_connection_t) -> XCBConnection {
@@ -102,7 +102,7 @@ impl XCBRenderPictFormInfo {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl<'a> ToGlibPtr<'a, *mut ffi::xcb_render_pictforminfo_t> for &'a XCBRenderPictFormInfo {
     type Storage = &'a XCBRenderPictFormInfo;
 
@@ -112,7 +112,7 @@ impl<'a> ToGlibPtr<'a, *mut ffi::xcb_render_pictforminfo_t> for &'a XCBRenderPic
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrNone<*mut ffi::xcb_render_pictforminfo_t> for XCBRenderPictFormInfo {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut ffi::xcb_render_pictforminfo_t) -> XCBRenderPictFormInfo {
@@ -120,7 +120,7 @@ impl FromGlibPtrNone<*mut ffi::xcb_render_pictforminfo_t> for XCBRenderPictFormI
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrFull<*mut ffi::xcb_render_pictforminfo_t> for XCBRenderPictFormInfo {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut ffi::xcb_render_pictforminfo_t) -> XCBRenderPictFormInfo {
@@ -159,7 +159,7 @@ impl XCBScreen {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl<'a> ToGlibPtr<'a, *mut ffi::xcb_screen_t> for &'a XCBScreen {
     type Storage = &'a XCBScreen;
 
@@ -169,7 +169,7 @@ impl<'a> ToGlibPtr<'a, *mut ffi::xcb_screen_t> for &'a XCBScreen {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrNone<*mut ffi::xcb_screen_t> for XCBScreen {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut ffi::xcb_screen_t) -> XCBScreen {
@@ -177,7 +177,7 @@ impl FromGlibPtrNone<*mut ffi::xcb_screen_t> for XCBScreen {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrFull<*mut ffi::xcb_screen_t> for XCBScreen {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut ffi::xcb_screen_t) -> XCBScreen {
@@ -279,7 +279,7 @@ impl XCBVisualType {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl<'a> ToGlibPtr<'a, *mut ffi::xcb_visualtype_t> for &'a XCBVisualType {
     type Storage = &'a XCBVisualType;
 
@@ -289,7 +289,7 @@ impl<'a> ToGlibPtr<'a, *mut ffi::xcb_visualtype_t> for &'a XCBVisualType {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrNone<*mut ffi::xcb_visualtype_t> for XCBVisualType {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut ffi::xcb_visualtype_t) -> XCBVisualType {
@@ -297,7 +297,7 @@ impl FromGlibPtrNone<*mut ffi::xcb_visualtype_t> for XCBVisualType {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrFull<*mut ffi::xcb_visualtype_t> for XCBVisualType {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut ffi::xcb_visualtype_t) -> XCBVisualType {
@@ -336,7 +336,7 @@ impl Device {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl<'a> ToGlibPtr<'a, *mut ffi::cairo_device_t> for &'a Device {
     type Storage = &'a Device;
 
@@ -346,7 +346,7 @@ impl<'a> ToGlibPtr<'a, *mut ffi::cairo_device_t> for &'a Device {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrNone<*mut ffi::cairo_device_t> for Device {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut ffi::cairo_device_t) -> Device {
@@ -354,7 +354,7 @@ impl FromGlibPtrNone<*mut ffi::cairo_device_t> for Device {
     }
 }
 
-#[cfg(feature = "glib")]
+#[cfg(feature = "use_glib")]
 impl FromGlibPtrFull<*mut ffi::cairo_device_t> for Device {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut ffi::cairo_device_t) -> Device {


### PR DESCRIPTION
In addition it might make sense to also implement the new traits for the
types that don't use glib_wrapper!()


See https://github.com/gtk-rs/glib/pull/198