### PR TITLE
ImageSurface: return a Result<ImageSurface, Status> from the creation functions

### DIFF
--- a/cairo-sys-rs/src/enums.rs
+++ b/cairo-sys-rs/src/enums.rs
@@ -49,7 +49,10 @@ pub enum Status {
     DeviceFinished,
     // CAIRO_MIME_TYPE_JBIG2_GLOBAL_ID has been used on at least one image but no
     // image provided `JBig2Global` (Since 1.14)
-    // JBig2GlobalMissing,
+    JBig2GlobalMissing,
+    PngError,
+    FreetypeError,
+    Win32GdiError,
     LastStatus
 }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -115,7 +115,7 @@ mod tests {
     use ffi::enums::Format;
 
     fn make_cr() -> Context {
-        let surface = ImageSurface::create(Format::Rgb24, 1, 1);
+        let surface = ImageSurface::create(Format::Rgb24, 1, 1).unwrap ();
 
         Context::new(&surface)
     }

--- a/src/win32_surface.rs
+++ b/src/win32_surface.rs
@@ -11,6 +11,7 @@ use glib::translate::*;
 use ffi;
 use ffi::enums::{Format, SurfaceType};
 use surface::{Surface, SurfaceExt};
+use Status;
 
 #[derive(Debug)]
 pub struct Win32Surface(Surface);
@@ -25,15 +26,20 @@ impl Win32Surface {
     }
 
     #[doc(hidden)]
-    pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_surface_t) -> Win32Surface {
-        Self::from(Surface::from_raw_full(ptr)).unwrap()
+    pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_surface_t) -> Result<Win32Surface, Status> {
+        let surface = Self::from(Surface::from_raw_full(ptr)).unwrap();
+        let status = surface.status();
+        match status {
+            Status::Success => Ok(surface),
+            _ => Err(status)
+        }
     }
 
-    pub fn create(hdc: winapi::HDC) -> Win32Surface {
+    pub fn create(hdc: winapi::HDC) -> Result<Win32Surface, Status> {
         unsafe { Self::from_raw_full(ffi::cairo_win32_surface_create(hdc)) }
     }
 
-    pub fn create_with_dib(format: Format, width: i32, height: i32) -> Win32Surface {
+    pub fn create_with_dib(format: Format, width: i32, height: i32) -> Result<Win32Surface, Status> {
         unsafe { Self::from_raw_full(ffi::cairo_win32_surface_create_with_dib(format, width, height)) }
     }
 
@@ -41,13 +47,13 @@ impl Win32Surface {
                            format: Format,
                            width: i32,
                            height: i32)
-                           -> Win32Surface {
+                           -> Result<Win32Surface, Status> {
         unsafe {
             Self::from_raw_full(ffi::cairo_win32_surface_create_with_ddb(hdc, format, width, height))
         }
     }
 
-    pub fn printing_surface_create(hdc: winapi::HDC) -> Win32Surface {
+    pub fn printing_surface_create(hdc: winapi::HDC) -> Result<Win32Surface, Status> {
         unsafe { Self::from_raw_full(ffi::cairo_win32_printing_surface_create(hdc)) }
     }
 }


### PR DESCRIPTION
When Cairo gets asked to create a surface, it will always return a
non-null cairo_surface_t*, but its cairo_surface_status() may not be
CAIRO_STATUS_SUCCESS.

For the Rust-side surface creation functions, we now return a
Result<ImageSurface, Status>.  If Ok(), then the surface is in
Status::Success.  If Err(), we return the status from Cairo's error
surface.

This means that "image_surface = from_glib_full(ptr)" needs to be
passed a surface that is *not* in error.  This function will panic if
passed a Cairo surface that is in an error state.