### PR TITLE
Mark `ImageSurface` and `PDFSurface` as `Send`

### DIFF
--- a/src/image_surface.rs
+++ b/src/image_surface.rs
@@ -150,6 +150,8 @@ impl Clone for ImageSurface {
     }
 }
 
+unsafe impl Send for ImageSurface {}
+
 pub struct ImageSurfaceData<'a> {
     surface: &'a mut ImageSurface,
     slice: &'a mut [u8],

--- a/src/pdf_surface.rs
+++ b/src/pdf_surface.rs
@@ -68,6 +68,8 @@ impl Clone for PDFSurface {
     }
 }
 
+unsafe impl Send for PDFSurface {}
+
 #[cfg(feature = "glib")]
 impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for PDFSurface {
     type Storage = &'a Surface;


### PR DESCRIPTION
While following [this guide](https://www.cairographics.org/threaded_animation_with_cairo/), I found that `Surface` wasn't `Send`. I assume that if it is possible to share it between threads in C, it should also be possible in Rust.