### PR TITLE
Add T: io::Write support to PDFSurface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ name = "cairo"
 [features]
 purge-lgpl-docs = ["gtk-rs-lgpl-docs"]
 png = ["cairo-sys-rs/png"]
+pdf = ["cairo-sys-rs/pdf"]
 use_glib = ["glib", "glib-sys"]
 embed-lgpl-docs = ["gtk-rs-lgpl-docs"]
 v1_12 = ["cairo-sys-rs/v1_12"]

--- a/cairo-sys-rs/Cargo.toml
+++ b/cairo-sys-rs/Cargo.toml
@@ -19,6 +19,7 @@ v1_12 = []
 v1_14 = ["v1_12"]
 xlib = ["x11"]
 png = []
+pdf = []
 xcb = []
 
 [dependencies]

--- a/cairo-sys-rs/src/enums.rs
+++ b/cairo-sys-rs/src/enums.rs
@@ -328,6 +328,14 @@ pub enum RegionOverlap {
     Part,
 }
 
+#[cfg(feature = "pdf")]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PDFVersion {
+    _1_4,
+    _1_5,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -50,6 +50,9 @@ use enums::{
     Operator,
 };
 
+#[cfg(feature = "pdf")]
+use enums::PDFVersion;
+
 macro_rules! debug_impl {
     ($name:ty) => {
         impl ::std::fmt::Debug for $name {
@@ -544,6 +547,20 @@ extern "C" {
     pub fn cairo_image_surface_create_from_png_stream(read_func: cairo_read_func_t, closure: *mut c_void) -> *mut cairo_surface_t;
     #[cfg(any(feature = "png", feature = "dox"))]
     pub fn cairo_surface_write_to_png_stream(surface: *mut cairo_surface_t, write_func: cairo_write_func_t, closure: *mut c_void) -> Status;
+
+    #[cfg(feature = "pdf")]
+    pub fn cairo_pdf_surface_create (filename: *const c_char,
+                                     width_in_points: c_double,
+                                     height_in_points: c_double) -> *mut cairo_surface_t;
+
+    #[cfg(feature = "pdf")]
+    pub fn cairo_pdf_surface_create_for_stream (write_func: cairo_write_func_t,
+                                                closure: *mut c_void,
+                                                width_in_points: c_double,
+                                                height_in_points: c_double) -> *mut cairo_surface_t;
+
+    #[cfg(feature = "pdf")]
+    pub fn cairo_pdf_surface_restrict_to_version (surface: *mut cairo_surface_t, version: PDFVersion);
 
     // CAIRO XCB
     #[cfg(any(feature = "xcb", feature = "dox"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ pub use image_surface::{
     ImageSurfaceData,
 };
 
+#[cfg(feature = "pdf")]
 pub use pdf_surface::PDFSurface;
 
 #[cfg(any(feature = "xcb", feature = "dox"))]
@@ -115,6 +116,7 @@ pub mod prelude;
 mod font;
 mod context;
 mod error;
+#[cfg(feature = "pdf")]
 mod pdf_surface;
 mod image_surface;
 #[cfg(any(feature = "png", feature = "dox"))]

--- a/src/pdf_surface.rs
+++ b/src/pdf_surface.rs
@@ -19,12 +19,6 @@ use glib::translate::*;
 
 pub struct PDFSurface(Surface);
 
-extern "C" {
-    pub fn cairo_pdf_surface_create (filename: *const c_char,
-                                     width_in_points: c_double,
-                                     height_in_points: c_double) -> *mut ffi::cairo_surface_t;
-}
-
 impl PDFSurface {
     pub fn from(surface: Surface) -> Result<PDFSurface, Surface> {
         if surface.get_type() == SurfaceType::Pdf {
@@ -44,7 +38,7 @@ impl PDFSurface {
         // Convert: AsRef<Path> -> Cow<str> -> str
         let s = filename.as_ref().to_string_lossy().into_owned();
         let file = CString::new(s).unwrap();
-        unsafe { Self::from_raw_full(cairo_pdf_surface_create(file.as_ptr(), width, height)) }
+        unsafe { Self::from_raw_full(ffi::cairo_pdf_surface_create(file.as_ptr(), width, height)) }
     }
 }
 


### PR DESCRIPTION
When generating PDFs having to go around a temporary file is kind of annoying, I couldn't come up with a nice way to just expose the closure way but at least you can use `io::Write` to write to a `Vec<u8>` and similar.

I'm not entirely sure how safe the approach I took because I don't know how the whole GLib/`Clone` business is, but I think it *should* be safe.