### PR TITLE
Remove unneeded `mut`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,8 @@ install:
   - IF "%BITS%" == "64" SET ARCH=x86_64
   - curl -sSf -o rustup-init.exe https://win.rustup.rs
   - rustup-init.exe --default-host "%ARCH%-pc-windows-gnu" --default-toolchain %RUST% -y
+  # Remove old dll that broke test. See https://github.com/gtk-rs/cairo/pull/160
+  - IF "%BITS%" == "32" ren C:\Users\appveyor\.rustup\toolchains\stable-i686-pc-windows-gnu\bin\libgcc_s_dw2-1.dll _libgcc_s_dw2-1.dll
   - SET PATH=C:\Users\appveyor\.cargo\bin;C:\msys64\mingw%BITS%\bin;%PATH%;C:\msys64\usr\bin
   - rustc -Vv
   - cargo -Vv

--- a/src/image_surface_png.rs
+++ b/src/image_surface_png.rs
@@ -33,7 +33,7 @@ struct ReadEnv<'a, R: 'a + Read> {
 unsafe extern "C" fn read_func<R: Read>(closure: *mut c_void, data: *mut u8, len: c_uint) -> Status {
     let _cbguard = CallbackGuard;
     let read_env: &mut ReadEnv<R> = &mut *(closure as *mut ReadEnv<R>);
-    let mut buffer = slice::from_raw_parts_mut(data, len as usize);
+    let buffer = slice::from_raw_parts_mut(data, len as usize);
     match read_env.reader.read_exact(buffer) {
         Ok(()) => Status::Success,
         Err(error) => {


### PR DESCRIPTION
```
warning: variable does not need to be mutable
  --> D:/eap/rust/0/cairo\src\image_surface_png.rs:36:9
   |
36 |     let mut buffer = slice::from_raw_parts_mut(data, len as usize);
   |         ^^^^^^^^^^
   |
   = note: #[warn(unused_mut)] on by default
```

@GuillaumeGomez Not sure that it pass CI.