### PR TITLE
Use winapi 0.3.2 on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,3 @@ git = "https://github.com/gtk-rs/sys"
 [dependencies]
 c_vec = "~1.2"
 libc = "0.2"
-
-[target.'cfg(windows)'.dependencies]
-winapi = "0.2.7"

--- a/cairo-sys-rs/Cargo.toml
+++ b/cairo-sys-rs/Cargo.toml
@@ -26,7 +26,7 @@ x11 = { version = "2.16", features = ["xlib"], optional = true }
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2.7"
+winapi = { version = "0.3.2", features = ["windef"] }
 
 [build-dependencies]
 pkg-config = "0.3.7"

--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -10,7 +10,13 @@ extern crate libc;
 extern crate x11;
 
 #[cfg(windows)]
-extern crate winapi;
+extern crate winapi as winapi_orig;
+
+#[cfg(windows)]
+pub mod winapi {
+    pub use winapi_orig::shared::windef::HDC;
+}
+
 #[cfg(all(not(windows), feature = "dox"))]
 pub mod winapi {
    use libc::c_void;

--- a/src/win32_surface.rs
+++ b/src/win32_surface.rs
@@ -2,9 +2,6 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-#[cfg(windows)]
-extern crate winapi;
-#[cfg(all(not(windows), feature = "dox"))]
 pub use ffi::winapi;
 
 use std::ops::Deref;


### PR DESCRIPTION
cc @GuillaumeGomez , @sdroege 

@evmar Please, check this too, if you still use `cairo::Win32Surface` on Windows