### PR TITLE
remove versions from git dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,16 +34,13 @@ optional = true
 git = "https://github.com/gtk-rs/lgpl-docs"
 
 [dependencies.cairo-sys-rs]
-version = "0.6.0"
 path = "cairo-sys-rs"
 
 [dependencies.glib]
-version = "0.5.0"
 optional = true
 git = "https://github.com/gtk-rs/glib"
 
 [dependencies.glib-sys]
-version = "0.6.0"
 optional = true
 git = "https://github.com/gtk-rs/sys"
 


### PR DESCRIPTION
Again: same as gtk-rs/pangocairo#20
I chose to do it a little different in this one because of the optionality of glib, and to keep it similarly looking.