### PR TITLE
Finalize PDF, SVG, PS work from #234

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ git = "https://github.com/gtk-rs/sys"
 
 [dependencies]
 libc = "0.2"
+bitflags = "1.0"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -58,6 +58,10 @@ pub type cairo_svg_unit_t = c_int;
 pub type cairo_text_cluster_flags_t = c_int;
 
 #[cfg(any(feature = "pdf", feature = "dox"))]
+pub type cairo_pdf_outline_flags_t = c_int;
+#[cfg(any(feature = "pdf", feature = "dox"))]
+pub type cairo_pdf_metadata_t = c_int;
+#[cfg(any(feature = "pdf", feature = "dox"))]
 pub type cairo_pdf_version_t = c_int;
 #[cfg(any(feature = "svg", feature = "dox"))]
 pub type cairo_svg_version_t = c_int;
@@ -258,6 +262,12 @@ pub struct cairo_bool_t{
 impl cairo_bool_t {
     pub fn as_bool(self) -> bool {
         self.value != 0
+    }
+}
+
+impl From<bool> for cairo_bool_t {
+    fn from(b: bool) -> cairo_bool_t {
+        cairo_bool_t { value: b as _ }
     }
 }
 
@@ -593,9 +603,31 @@ extern "C" {
     #[cfg(any(feature = "pdf", feature = "dox"))]
     pub fn cairo_pdf_surface_restrict_to_version (surface: *mut cairo_surface_t, version: cairo_pdf_version_t);
     #[cfg(any(feature = "pdf", feature = "dox"))]
+    pub fn cairo_pdf_get_versions (versions: *mut *mut cairo_pdf_version_t,
+                                   num_versions: *mut c_int);
+    #[cfg(any(feature = "pdf", feature = "dox"))]
+    pub fn cairo_pdf_version_to_string (version: cairo_pdf_version_t) -> *const c_char;
+    #[cfg(any(feature = "pdf", feature = "dox"))]
     pub fn cairo_pdf_surface_set_size (surface: *mut cairo_surface_t,
                                       width_in_points: f64,
                                       height_in_points: f64);
+    #[cfg(any(feature = "pdf", feature = "dox"))]
+    pub fn cairo_pdf_surface_add_outline (surface: *mut cairo_surface_t,
+                                          parent_id: c_int,
+                                          utf8: *const c_char,
+                                          link_attribs: *const c_char,
+                                          flags: cairo_pdf_outline_flags_t) -> c_int;
+    #[cfg(any(feature = "pdf", feature = "dox"))]
+    pub fn cairo_pdf_surface_set_metadata (surface: *mut cairo_surface_t,
+                                           metadata: cairo_pdf_metadata_t,
+                                           utf8: *const c_char);
+    #[cfg(any(feature = "pdf", feature = "dox"))]
+    pub fn cairo_pdf_surface_set_page_label (surface: *mut cairo_surface_t,
+                                             utf8: *const c_char);
+    #[cfg(any(feature = "pdf", feature = "dox"))]
+    pub fn cairo_pdf_surface_set_thumbnail_size (surface: *mut cairo_surface_t,
+                                                 width: c_int,
+                                                 height: c_int);
 
     // CAIRO SVG
     #[cfg(any(feature = "svg", feature = "dox"))]
@@ -613,6 +645,12 @@ extern "C" {
     pub fn cairo_svg_surface_get_document_unit(surface: *const cairo_surface_t) -> cairo_svg_unit_t;
     #[cfg(any(feature = "svg", feature = "dox"))]
     pub fn cairo_svg_surface_set_document_unit(surface: *mut cairo_surface_t, unit: cairo_svg_unit_t);
+    #[cfg(any(feature = "svg", feature = "dox"))]
+    pub fn cairo_svg_get_versions (versions: *mut *mut cairo_svg_version_t,
+                                   num_versions: *mut c_int);
+    #[cfg(any(feature = "svg", feature = "dox"))]
+    pub fn cairo_svg_version_to_string (version: cairo_svg_version_t) -> *const c_char;
+
     // CAIRO PS
     #[cfg(any(feature = "ps", feature = "dox"))]
     pub fn cairo_ps_surface_create (filename: *const c_char,
@@ -625,6 +663,11 @@ extern "C" {
                                                height_in_points: c_double) -> *mut cairo_surface_t;
     #[cfg(any(feature = "ps", feature = "dox"))]
     pub fn cairo_ps_surface_restrict_to_level (surface: *mut cairo_surface_t, version: cairo_ps_level_t);
+    #[cfg(any(feature = "ps", feature = "dox"))]
+    pub fn cairo_ps_get_levels (levels: *mut *mut cairo_ps_level_t,
+                                   num_levels: *mut c_int);
+    #[cfg(any(feature = "ps", feature = "dox"))]
+    pub fn cairo_ps_level_to_string (level: cairo_ps_level_t) -> *const c_char;
     #[cfg(any(feature = "ps", feature = "dox"))]
     pub fn cairo_ps_surface_set_eps (surface: *mut cairo_surface_t, eps: cairo_bool_t);
     #[cfg(any(feature = "ps", feature = "dox"))]
@@ -949,6 +992,17 @@ pub const FORMAT_RGB30: i32 = 5;
 pub const REGION_OVERLAP_IN: i32 = 0;
 pub const REGION_OVERLAP_OUT: i32 = 1;
 pub const REGION_OVERLAP_PART: i32 = 2;
+pub const PDF_OUTLINE_FLAG_OPEN: i32 = 0x1;
+pub const PDF_OUTLINE_FLAG_BOLD: i32 = 0x2;
+pub const PDF_OUTLINE_FLAG_ITALIC: i32 = 0x4;
+pub const PDF_OUTLINE_FLAG__ALL: i32 = PDF_OUTLINE_FLAG_OPEN|PDF_OUTLINE_FLAG_BOLD|PDF_OUTLINE_FLAG_ITALIC;
+pub const PDF_METADATA_TITLE: i32 = 0;
+pub const PDF_METADATA_AUTHOR: i32 = 1;
+pub const PDF_METADATA_SUBJECT: i32 = 2;
+pub const PDF_METADATA_KEYWORDS: i32 = 3;
+pub const PDF_METADATA_CREATOR: i32 = 4;
+pub const PDF_METADATA_CREATE_DATE: i32 = 5;
+pub const PDF_METADATA_MOD_DATE: i32 = 6;
 pub const PDF_VERSION__1_4: i32 = 0;
 pub const PDF_VERSION__1_5: i32 = 1;
 pub const SVG_VERSION__1_1: i32 = 0;

--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2013-2016, The Gtk-rs Project Developers.
+// Copyright 2013-2019, The Gtk-rs Project Developers.
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 

--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -267,7 +267,8 @@ impl cairo_bool_t {
 
 impl From<bool> for cairo_bool_t {
     fn from(b: bool) -> cairo_bool_t {
-        cairo_bool_t { value: b as _ }
+        let value = if b { 1 } else { 0 };
+        cairo_bool_t { value }
     }
 }
 
@@ -995,7 +996,6 @@ pub const REGION_OVERLAP_PART: i32 = 2;
 pub const PDF_OUTLINE_FLAG_OPEN: i32 = 0x1;
 pub const PDF_OUTLINE_FLAG_BOLD: i32 = 0x2;
 pub const PDF_OUTLINE_FLAG_ITALIC: i32 = 0x4;
-pub const PDF_OUTLINE_FLAG__ALL: i32 = PDF_OUTLINE_FLAG_OPEN|PDF_OUTLINE_FLAG_BOLD|PDF_OUTLINE_FLAG_ITALIC;
 pub const PDF_METADATA_TITLE: i32 = 0;
 pub const PDF_METADATA_AUTHOR: i32 = 1;
 pub const PDF_METADATA_SUBJECT: i32 = 2;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,4 @@
-// Copyright 2013-2018, The Gtk-rs Project Developers.
+// Copyright 2013-2019, The Gtk-rs Project Developers.
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,9 +2,6 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-use ffi;
-
-
 pub const MIME_TYPE_JPEG: &str = "image/jpeg";
 pub const MIME_TYPE_PNG: &str = "image/png";
 pub const MIME_TYPE_JP2: &str = "image/jp2";
@@ -19,6 +16,3 @@ pub const MIME_TYPE_EPS: &str = "application/postscript";
 pub const MIME_TYPE_EPS_PARAMS: &str = "application/x-cairo.eps.params";
 
 pub const PDF_OUTLINE_ROOT: i32 = 0;
-pub const PDF_OUTLINE_OPEN: i32 = ffi::PDF_OUTLINE_FLAG_OPEN;
-pub const PDF_OUTLINE_BOLD: i32 = ffi::PDF_OUTLINE_FLAG_BOLD;
-pub const PDF_OUTLINE_ITALIC: i32 = ffi::PDF_OUTLINE_FLAG_ITALIC;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,6 +2,9 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
+use ffi;
+
+
 pub const MIME_TYPE_JPEG: &str = "image/jpeg";
 pub const MIME_TYPE_PNG: &str = "image/png";
 pub const MIME_TYPE_JP2: &str = "image/jp2";
@@ -14,3 +17,8 @@ pub const MIME_TYPE_CCITT_FAX: &str = "image/g3fax";
 pub const MIME_TYPE_CCITT_FAX_PARAMS: &str = "application/x-cairo.ccitt.params";
 pub const MIME_TYPE_EPS: &str = "application/postscript";
 pub const MIME_TYPE_EPS_PARAMS: &str = "application/x-cairo.eps.params";
+
+pub const PDF_OUTLINE_ROOT: i32 = 0;
+pub const PDF_OUTLINE_OPEN: i32 = ffi::PDF_OUTLINE_FLAG_OPEN;
+pub const PDF_OUTLINE_BOLD: i32 = ffi::PDF_OUTLINE_FLAG_BOLD;
+pub const PDF_OUTLINE_ITALIC: i32 = ffi::PDF_OUTLINE_FLAG_ITALIC;

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1229,6 +1229,54 @@ gvalue_impl!(RegionOverlap, ffi::gobject::cairo_gobject_region_overlap_get_type)
 
 #[cfg(any(feature = "pdf", feature = "dox"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PdfMetadata {
+    Title,
+    Author,
+    Subject,
+    Keywords,
+    Creator,
+    CreateDate,
+    ModDate,
+    #[doc(hidden)]
+    __Unknown(i32),
+}
+
+#[cfg(any(feature = "pdf", feature = "dox"))]
+#[doc(hidden)]
+impl Into<ffi::cairo_pdf_metadata_t> for PdfMetadata {
+    fn into(self) -> ffi::cairo_pdf_metadata_t {
+        match self {
+            PdfMetadata::Title => ffi::PDF_METADATA_TITLE,
+            PdfMetadata::Author => ffi::PDF_METADATA_AUTHOR,
+            PdfMetadata::Subject => ffi::PDF_METADATA_SUBJECT,
+            PdfMetadata::Keywords => ffi::PDF_METADATA_KEYWORDS,
+            PdfMetadata::Creator => ffi::PDF_METADATA_CREATOR,
+            PdfMetadata::CreateDate => ffi::PDF_METADATA_CREATE_DATE,
+            PdfMetadata::ModDate => ffi::PDF_METADATA_MOD_DATE,
+            PdfMetadata::__Unknown(value) => value,
+        }
+    }
+}
+
+#[cfg(any(feature = "pdf", feature = "dox"))]
+#[doc(hidden)]
+impl From<ffi::cairo_pdf_metadata_t> for PdfMetadata {
+    fn from(value: ffi::cairo_pdf_metadata_t) -> Self {
+        match value {
+            ffi::PDF_METADATA_TITLE => PdfMetadata::Title,
+            ffi::PDF_METADATA_AUTHOR => PdfMetadata::Author,
+            ffi::PDF_METADATA_SUBJECT => PdfMetadata::Subject,
+            ffi::PDF_METADATA_KEYWORDS => PdfMetadata::Keywords,
+            ffi::PDF_METADATA_CREATOR => PdfMetadata::Creator,
+            ffi::PDF_METADATA_CREATE_DATE => PdfMetadata::CreateDate,
+            ffi::PDF_METADATA_MOD_DATE => PdfMetadata::ModDate,
+            value => PdfMetadata::__Unknown(value),
+        }
+    }
+}
+
+#[cfg(any(feature = "pdf", feature = "dox"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PdfVersion {
     _1_4,
     _1_5,

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,4 +1,4 @@
-// Copyright 2013-2015, The Gtk-rs Project Developers.
+// Copyright 2013-2019, The Gtk-rs Project Developers.
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1227,6 +1227,14 @@ impl From<ffi::cairo_region_overlap_t> for RegionOverlap {
 #[cfg(feature = "use_glib")]
 gvalue_impl!(RegionOverlap, ffi::gobject::cairo_gobject_region_overlap_get_type);
 
+bitflags! {
+    pub struct PdfOutline: i32 {
+        const OPEN = ffi::PDF_OUTLINE_FLAG_OPEN;
+        const BOLD = ffi::PDF_OUTLINE_FLAG_BOLD;
+        const ITALIC = ffi::PDF_OUTLINE_FLAG_ITALIC;
+    }
+}
+
 #[cfg(any(feature = "pdf", feature = "dox"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PdfMetadata {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@
 extern crate cairo_sys as ffi;
 extern crate libc;
 
+#[macro_use]
+extern crate bitflags;
+
 #[cfg(feature = "use_glib")]
 #[macro_use]
 extern crate glib;

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2016, The Gtk-rs Project Developers.
+// Copyright 2018-2019, The Gtk-rs Project Developers.
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -181,6 +181,9 @@ impl<W: io::Write> Writer<W> {
         Writer { writer }
     }
 
+    pub fn writer(&self) -> &W { self.writer.writer() }
+    pub fn writer_mut(&mut self) -> &mut W { self.writer.writer_mut() }
+
     pub fn finish(self) -> W {
         self.writer.finish()
     }
@@ -203,6 +206,12 @@ impl<W: io::Write> AsRef<File> for Writer<W> {
 impl<W: io::Write> AsRef<Surface> for Writer<W> {
     fn as_ref(&self) -> &Surface {
         &self.writer.surface.as_ref()
+    }
+}
+
+impl<W: io::Write + AsRef<[u8]>> AsRef<[u8]> for Writer<W> {
+    fn as_ref(&self) -> &[u8] {
+        &self.writer.writer().as_ref()
     }
 }
 

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -36,6 +36,7 @@ pub fn version_to_string(version: PdfVersion) -> Option<String> {
     }
 }
 
+/// A PDF surface that writes to a file
 pub struct File {
     inner: Surface,
 }
@@ -155,7 +156,14 @@ impl FromGlibPtrFull<*mut ffi::cairo_surface_t> for File {
 }
 
 
-
+/// A PDF surface that writes to a generic `io::Write` type (owning variant)
+///
+/// The `Writer` takes ownership of the write object.
+/// Once you're done using the surface, you can obtain the write object
+/// back using the `finish()` method.
+///
+/// If you would like the surface to reference the write object
+/// instead, use `RefWriter`.
 pub struct Writer<W: io::Write> {
     writer: support::Writer<File, W>,
 }
@@ -205,6 +213,13 @@ impl<'a, W: io::Write> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Writer<W> {
 }
 
 
+/// A PDF surface that writes to a generic `io::Write` type (referencing variant)
+///
+/// The `RefWriter` references the write object,
+/// which is why a lifetime parameter is required.
+///
+/// If you would like the surface to own the write object
+/// instead, use `Writer`.
 pub struct RefWriter<'w, W: io::Write + 'w> {
     writer: support::RefWriter<'w, File, W>,
 }

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -107,12 +107,12 @@ impl FromGlibPtrFull<*mut ffi::cairo_surface_t> for File {
 
 
 pub struct Writer<W: io::Write> {
-    writer: support::Writer_<File, W>,
+    writer: support::Writer<File, W>,
 }
 
 impl<W: io::Write> Writer<W> {
     pub fn new(width: f64, height: f64, writer: W) -> Writer<W> {
-        let writer = support::Writer_::new(ffi::cairo_pdf_surface_create_for_stream,
+        let writer = support::Writer::new(ffi::cairo_pdf_surface_create_for_stream,
             width, height, writer);
 
         Writer { writer }

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2016, The Gtk-rs Project Developers.
+// Copyright 2018-2019, The Gtk-rs Project Developers.
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -29,10 +29,10 @@ pub fn get_levels() -> Vec<PsLevel> {
     lvls_slice.iter().map(|v| PsLevel::from(*v)).collect()
 }
 
-pub fn level_to_string(level: PsLevel) -> Option<String> {
+pub fn level_to_string(level: PsLevel) -> Option<&'static str> {
     unsafe {
         let res = ffi::cairo_ps_level_to_string(level.into());
-        res.as_ref().and_then(|cstr| CStr::from_ptr(cstr as _).to_str().ok()).map(String::from)
+        res.as_ref().and_then(|cstr| CStr::from_ptr(cstr as _).to_str().ok())
     }
 }
 
@@ -129,8 +129,9 @@ impl File {
     }
 
     pub fn cairo_ps_surface_dsc_comment(&self, comment: &str) {
+        let comment = CString::new(comment).unwrap();
         unsafe {
-            ffi::cairo_ps_surface_dsc_comment(self.inner.to_raw_none(), comment.as_ptr() as _);
+            ffi::cairo_ps_surface_dsc_comment(self.inner.to_raw_none(), comment.as_ptr());
         }
     }
 

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -177,6 +177,9 @@ impl<W: io::Write> Writer<W> {
         Writer { writer }
     }
 
+    pub fn writer(&self) -> &W { self.writer.writer() }
+    pub fn writer_mut(&mut self) -> &mut W { self.writer.writer_mut() }
+
     pub fn finish(self) -> W {
         self.writer.finish()
     }
@@ -199,6 +202,12 @@ impl<W: io::Write> AsRef<File> for Writer<W> {
 impl<W: io::Write> AsRef<Surface> for Writer<W> {
     fn as_ref(&self) -> &Surface {
         &self.writer.surface.as_ref()
+    }
+}
+
+impl<W: io::Write + AsRef<[u8]>> AsRef<[u8]> for Writer<W> {
+    fn as_ref(&self) -> &[u8] {
+        &self.writer.writer().as_ref()
     }
 }
 

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -8,15 +8,22 @@ use std::path::Path;
 use std::io;
 
 use ffi;
-use ::enums::{SurfaceType, PsLevel};
-use surface::{Surface, SurfaceExt};
-use support;
+use ::enums::PsLevel;
+use surface::Surface;
+use support::{self, FromRawSurface};
 
 #[cfg(feature = "use_glib")]
 use glib::translate::*;
 
+
 pub struct File {
     inner: Surface,
+}
+
+impl FromRawSurface for File {
+    unsafe fn from_raw_surface(surface: *mut ffi::cairo_surface_t) -> File {
+        File { inner: Surface::from_raw_full(surface) }
+    }
 }
 
 #[cfg(feature = "use_glib")]
@@ -34,7 +41,7 @@ impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for File {
 impl FromGlibPtrNone<*mut ffi::cairo_surface_t> for File {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut ffi::cairo_surface_t) -> File {
-        Self::from(from_glib_none(ptr)).unwrap()
+        File { inner: from_glib_none(ptr) }
     }
 }
 
@@ -42,7 +49,7 @@ impl FromGlibPtrNone<*mut ffi::cairo_surface_t> for File {
 impl FromGlibPtrBorrow<*mut ffi::cairo_surface_t> for File {
     #[inline]
     unsafe fn from_glib_borrow(ptr: *mut ffi::cairo_surface_t) -> File {
-        Self::from(from_glib_borrow(ptr)).unwrap()
+        File { inner: from_glib_borrow(ptr) }
     }
 }
 
@@ -50,37 +57,29 @@ impl FromGlibPtrBorrow<*mut ffi::cairo_surface_t> for File {
 impl FromGlibPtrFull<*mut ffi::cairo_surface_t> for File {
     #[inline]
     unsafe fn from_glib_full(ptr: *mut ffi::cairo_surface_t) -> File {
-        Self::from_raw_full(ptr)
+        Self::from_raw_surface(ptr)
     }
 }
 
 impl File {
-    #[doc(hidden)]
-    pub fn from(surface: Surface) -> Result<File, Surface> {
-        if surface.get_type() == SurfaceType::Ps {
-            Ok(File { inner: surface })
-        } else {
-            Err(surface)
-        }
-    }
-
-    #[doc(hidden)]
-    pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_surface_t) -> File {
-        Self::from(Surface::from_raw_full(ptr)).unwrap()
-    }
-
     pub fn new<P: AsRef<Path>>(width: f64, height: f64, path: P) -> File {
         let path = path.as_ref().to_string_lossy().into_owned();
         let path = CString::new(path).unwrap();
 
         unsafe {
-            Self::from_raw_full(ffi::cairo_ps_surface_create(path.as_ptr(), width, height))
+            Self::from_raw_surface(ffi::cairo_ps_surface_create(path.as_ptr(), width, height))
         }
     }
 
     pub fn restrict(&self, level: PsLevel) {
         unsafe {
             ffi::cairo_ps_surface_restrict_to_level(self.inner.to_raw_none(), level.into());
+        }
+    }
+
+    pub fn set_size(&self, width: f64, height: f64) {
+        unsafe {
+            ffi::cairo_ps_surface_set_size(self.inner.to_raw_none(), width, height);
         }
     }
 }
@@ -99,206 +98,200 @@ impl Deref for File {
     }
 }
 
-pub struct Buffer {
-    inner: Surface,
-    #[allow(unused)]
-    support: support::Buffer,
+impl AsRef<File> for File {
+    // This is included in order to be able to be generic over PS surfaces
+    fn as_ref(&self) -> &File { self }
 }
 
-impl Buffer {
-    pub fn new(width: f64, height: f64) -> Buffer {
-        let support = support::Buffer::new(ffi::cairo_ps_surface_create_for_stream, width, height);
 
-        Buffer {
-            inner: unsafe { Surface::from_raw_full(support.as_ptr()) },
-            support: support,
-        }
-    }
-
-    pub fn restrict(&self, level: PsLevel) {
-        unsafe {
-            ffi::cairo_ps_surface_restrict_to_level(self.inner.to_raw_none(), level.into());
-        }
-    }
+pub struct Writer<W: io::Write> {
+    writer: support::Writer<File, W>,
 }
 
-impl AsRef<[u8]> for Buffer {
-    fn as_ref(&self) -> &[u8] {
-        self.support.as_ref()
+impl<W: io::Write> Writer<W> {
+    pub fn new(width: f64, height: f64, writer: W) -> Writer<W> {
+        let writer = support::Writer::new(ffi::cairo_ps_surface_create_for_stream,
+            width, height, writer);
+
+        Writer { writer }
+    }
+
+    pub fn finish(self) -> W {
+        self.writer.finish()
     }
 }
 
-impl AsRef<Surface> for Buffer {
+impl<W: io::Write> Deref for Writer<W> {
+    type Target = File;
+
+    fn deref(&self) -> &File {
+        &self.writer.surface
+    }
+}
+
+impl<W: io::Write> AsRef<File> for Writer<W> {
+    fn as_ref(&self) -> &File {
+        &self.writer.surface
+    }
+}
+
+impl<W: io::Write> AsRef<Surface> for Writer<W> {
     fn as_ref(&self) -> &Surface {
-        &self.inner
-    }
-}
-
-impl Deref for Buffer {
-    type Target = Surface;
-
-    fn deref(&self) -> &Surface {
-        &self.inner
+        &self.writer.surface.as_ref()
     }
 }
 
 #[cfg(feature = "use_glib")]
-impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Buffer {
+impl<'a, W: io::Write> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Writer<W> {
     type Storage = &'a Surface;
 
     #[inline]
     fn to_glib_none(&'a self) -> Stash<'a, *mut ffi::cairo_surface_t, Self> {
-        let stash = self.inner.to_glib_none();
+        let stash = self.writer.surface.to_glib_none();
         Stash(stash.0, stash.1)
     }
 }
 
-pub struct Writer<'a> {
-    inner: Surface,
-    #[allow(unused)]
-    support: support::Writer<'a>,
+
+pub struct RefWriter<'w, W: io::Write + 'w> {
+    writer: support::RefWriter<'w, File, W>,
 }
 
-impl<'a> Writer<'a> {
-    pub fn new<'b, W: 'b + io::Write>(width: f64, height: f64, w: W) -> Writer<'b> {
-        let support = support::Writer::new(ffi::cairo_ps_surface_create_for_stream, width, height, w);
+impl<'w, W: io::Write + 'w> RefWriter<'w, W> {
+    pub fn new(width: f64, height: f64, writer: &'w mut W) -> RefWriter<'w, W> {
+        let writer = support::RefWriter::new(ffi::cairo_ps_surface_create_for_stream,
+            width, height, writer);
 
-        Writer {
-            inner: unsafe { Surface::from_raw_full(support.as_ptr()) },
-            support: support,
-        }
-    }
-
-    pub fn restrict(&self, level: PsLevel) {
-        unsafe {
-            ffi::cairo_ps_surface_restrict_to_level(self.inner.to_raw_none(), level.into());
-        }
+        RefWriter { writer }
     }
 }
 
-impl<'a> AsRef<Surface> for Writer<'a> {
+impl<'w, W: io::Write + 'w> Deref for RefWriter<'w, W> {
+    type Target = File;
+
+    fn deref(&self) -> &File {
+        &self.writer.surface
+    }
+}
+
+impl<'w, W: io::Write + 'w> AsRef<File> for RefWriter<'w, W> {
+    fn as_ref(&self) -> &File {
+        &self.writer.surface
+    }
+}
+
+impl<'w, W: io::Write + 'w> AsRef<Surface> for RefWriter<'w, W> {
     fn as_ref(&self) -> &Surface {
-        &self.inner
+        &self.writer.surface.as_ref()
     }
 }
 
-impl<'a> Deref for Writer<'a> {
-    type Target = Surface;
-
-    fn deref(&self) -> &Surface {
-        &self.inner
-    }
-}
- 
 #[cfg(feature = "use_glib")]
-impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Writer<'a> {
+impl<'a, 'w, W: io::Write + 'w> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for RefWriter<'w, W> {
     type Storage = &'a Surface;
 
     #[inline]
     fn to_glib_none(&'a self) -> Stash<'a, *mut ffi::cairo_surface_t, Self> {
-        let stash = self.inner.to_glib_none();
+        let stash = self.writer.surface.to_glib_none();
         Stash(stash.0, stash.1)
     }
 }
 
-pub struct Stream<'a> {
-    inner: Surface,
-    #[allow(unused)]
-    support: support::Stream<'a>,
-}
-
-impl<'a> Stream<'a> {
-    pub fn new<'b, F>(width: f64, height: f64, func: F) -> Stream<'b>
-        where F: 'b + FnMut(&[u8]) -> Result<(), ()>
-    {
-        let support = support::Stream::new(ffi::cairo_ps_surface_create_for_stream, width, height, func);
-
-        Stream {
-            inner: unsafe { Surface::from_raw_full(support.as_ptr()) },
-            support: support,
-        }
-    }
-
-    pub fn restrict(&self, level: PsLevel) {
-        unsafe {
-            ffi::cairo_ps_surface_restrict_to_level(self.inner.to_raw_none(), level.into());
-        }
-    }
-}
-
-impl<'a> AsRef<Surface> for Stream<'a> {
-    fn as_ref(&self) -> &Surface {
-        &self.inner
-    }
-}
-
-impl<'a> Deref for Stream<'a> {
-    type Target = Surface;
-
-    fn deref(&self) -> &Surface {
-        &self.inner
-    }
-}
- 
-#[cfg(feature = "use_glib")]
-impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Stream<'a> {
-    type Storage = &'a Surface;
-
-    #[inline]
-    fn to_glib_none(&'a self) -> Stash<'a, *mut ffi::cairo_surface_t, Self> {
-        let stash = self.inner.to_glib_none();
-        Stash(stash.0, stash.1)
-    }
-}
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use surface::Surface;
+    use surface::SurfaceExt;
     use context::*;
     use tempfile::tempfile;
 
-    fn draw<T: AsRef<Surface>>(surface: &T) {
-        let cr = Context::new(surface);
+    fn draw<T: AsRef<File>>(surface: &T) {
+        let cr = Context::new(surface.as_ref());
+
+        // Note: Not using RGBA here as PS doesn't natively support
+        // semi-transparency and Cairo would then embed a rasterized bitmap
 
         cr.set_line_width(25.0);
 
-        cr.set_source_rgba(1.0, 0.0, 0.0, 0.5);
+        cr.set_source_rgb(1.0, 0.0, 0.0);
         cr.line_to(0.,0.);
         cr.line_to(100.,100.);
         cr.stroke();
 
-        cr.set_source_rgba(0.0, 0.0, 1.0, 0.5);
+        cr.set_source_rgb(0.0, 0.0, 1.0);
         cr.line_to(0.,100.);
         cr.line_to(100.,0.);
         cr.stroke();
     }
 
+    fn draw_in_buffer() -> Vec<u8> {
+        let buffer: Vec<u8> = vec![];
+
+        let surface = Writer::new(100., 100., buffer);
+        draw(&surface);
+        surface.finish()
+    }
+
     #[test]
-    fn buffer() {
-        let surface = Buffer::new(100., 100.);
+    #[cfg(unix)]
+    fn file() {
+        let surface = File::new(100., 100., "/dev/null");
         draw(&surface);
         surface.finish();
     }
 
     #[test]
     fn writer() {
-        let mut file = tempfile().expect("tempfile failed");
+        let file = tempfile().expect("tempfile failed");
         let surface = Writer::new(100., 100., file);
+
+        draw(&surface);
+        let file = surface.finish();
+
+        let buffer = draw_in_buffer();
+        let file_size = file.metadata().unwrap().len();
+        assert_eq!(file_size, buffer.len() as u64);
+    }
+
+    #[test]
+    fn ref_writer() {
+        let mut file = tempfile().expect("tempfile failed");
+        let surface = RefWriter::new(100., 100., &mut file);
 
         draw(&surface);
         surface.finish();
     }
 
     #[test]
-    fn stream() {
-        let mut vec = Vec::<u8>::new();
-        let surface = Stream::new(100., 100., |data| {
-            vec.extend(data);
-            Ok(())
-        });
+    fn buffer() {
+        let buffer = draw_in_buffer();
 
+        let header = b"%!PS-Adobe";
+        assert_eq!(&buffer[..header.len()], header);
+    }
+
+    #[test]
+    fn custom_writer() {
+        struct CustomWriter(usize);
+
+        impl io::Write for CustomWriter {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.0 += buf.len();
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> io::Result<()> { Ok(()) }
+        }
+
+        let custom_writer = CustomWriter(0);
+
+        let surface = Writer::new(20., 20., custom_writer);
+        surface.set_size(100., 100.);
         draw(&surface);
-        surface.finish();
+        let custom_writer = surface.finish();
+
+        let buffer = draw_in_buffer();
+
+        assert_eq!(custom_writer.0, buffer.len());
     }
 }

--- a/src/ps.rs
+++ b/src/ps.rs
@@ -36,6 +36,7 @@ pub fn level_to_string(level: PsLevel) -> Option<String> {
     }
 }
 
+/// A PostScript surface that writes to a file
 pub struct File {
     inner: Surface,
 }
@@ -155,6 +156,14 @@ impl AsRef<File> for File {
 }
 
 
+/// A PostScript surface that writes to a generic `io::Write` type (owning variant)
+///
+/// The `Writer` takes ownership of the write object.
+/// Once you're done using the surface, you can obtain the write object
+/// back using the `finish()` method.
+///
+/// If you would like the surface to reference the write object
+/// instead, use `RefWriter`.
 pub struct Writer<W: io::Write> {
     writer: support::Writer<File, W>,
 }
@@ -204,6 +213,13 @@ impl<'a, W: io::Write> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Writer<W> {
 }
 
 
+/// A PostScript surface that writes to a generic `io::Write` type (referencing variant)
+///
+/// The `RefWriter` references the write object,
+/// which is why a lifetime parameter is required.
+///
+/// If you would like the surface to own the write object
+/// instead, use `Writer`.
 pub struct RefWriter<'w, W: io::Write + 'w> {
     writer: support::RefWriter<'w, File, W>,
 }

--- a/src/support.rs
+++ b/src/support.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2016, The Gtk-rs Project Developers.
+// Copyright 2018-2019, The Gtk-rs Project Developers.
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 

--- a/src/support.rs
+++ b/src/support.rs
@@ -15,139 +15,16 @@ use surface::{Surface, SurfaceExt};
 
 pub type Constructor = unsafe extern fn (ffi::cairo_write_func_t, *mut c_void, c_double, c_double) -> *mut ffi::cairo_surface_t;
 
-pub struct Stream<'a> {
-    ptr: *mut ffi::cairo_surface_t,
-    func: *mut Box<'a + FnMut(&[u8]) -> Result<(), ()>>,
-}
-
-impl<'a> Stream<'a> {
-    pub fn new<'b, F>(constructor: Constructor, width: f64, height: f64, func: F) -> Stream<'b>
-        where F: 'b + FnMut(&[u8]) -> Result<(), ()>
-    {
-        unsafe {
-            unsafe extern fn write_to(func: *mut c_void, data: *mut c_uchar, length: c_uint) -> cairo_status_t
-            {
-                // This is perfectly fine, lifetimes don't really exist.
-                let mut func: Box<Box<FnMut(&[u8]) -> Result<(), ()>>> = Box::from_raw(func as *mut _);
-
-                let data = slice::from_raw_parts(data, length as usize);
-                let result = match func(data) {
-                    Ok(_) => Status::Success,
-                    Err(_) => Status::WriteError,
-                };
-
-                // We don't want to actually drop the closure, send it back
-                // into limbo.
-                Box::into_raw(func);
-
-                result.into()
-            }
-
-            // Type inference can't into this.
-            let func: *mut Box<'b + FnMut(&[u8]) -> Result<(), ()>> = Box::into_raw(Box::new(Box::new(func)));
-            let surface = constructor(Some(write_to), func as *mut _, width, height);
-
-            Stream {
-                ptr: surface,
-                func: func,
-            }
-        }
-    }
-
-    pub fn as_ptr(&self) -> *mut ffi::cairo_surface_t {
-        self.ptr
-    }
-}
-
-impl<'a> Drop for Stream<'a> {
-    fn drop(&mut self) {
-        unsafe {
-            Box::from_raw(self.func);
-        }
-    }
-}
-
-pub struct Writer<'a> {
-    inner: Stream<'a>,
-}
-
-impl<'a> Writer<'a> {
-    pub fn new<'b, W: 'b + io::Write>(constructor: Constructor, width: f64, height: f64, mut w: W) -> Writer<'b> {
-        Writer {
-            inner: Stream::new(constructor, width, height, move |data|
-                match w.write_all(data) {
-                    Ok(_) => Ok(()),
-                    Err(_) => Err(()),
-                }),
-        }
-    }
-
-    pub fn as_ptr(&self) -> *mut ffi::cairo_surface_t {
-        self.inner.as_ptr()
-    }
-}
-
-pub struct Buffer {
-    buffer: *mut Vec<u8>,
-    inner: Stream<'static>,
-}
-
-impl Buffer {
-    pub fn new(constructor: Constructor, width: f64, height: f64) -> Buffer {
-        let buffer = Box::into_raw(Box::new(Vec::new()));
-
-        Buffer {
-            buffer: buffer,
-            inner: Stream::new(constructor, width, height, move |data| {
-                unsafe {
-                    let mut out = Box::from_raw(buffer);
-                    out.extend(data);
-                    Box::into_raw(out);
-                }
-
-                Ok(())
-            }),
-        }
-    }
-
-    pub fn as_ptr(&self) -> *mut ffi::cairo_surface_t {
-        self.inner.as_ptr()
-    }
-}
-
-impl AsRef<[u8]> for Buffer {
-    fn as_ref(&self) -> &[u8] {
-        unsafe {
-            let vec = Box::from_raw(self.buffer);
-            let ptr = vec.as_ptr();
-            let len = vec.len();
-            Box::into_raw(vec);
-
-            slice::from_raw_parts(ptr, len)
-        }
-    }
-}
-
-impl Drop for Buffer {
-    fn drop(&mut self) {
-        unsafe {
-            Box::from_raw(self.buffer);
-        }
-    }
-}
-
-
-
 pub trait FromRawSurface {
     unsafe fn from_raw_surface(surface: *mut ffi::cairo_surface_t) -> Self;
 }
 
-pub struct Writer_<S: FromRawSurface + AsRef<Surface>, W: io::Write> {
+pub struct Writer<S: FromRawSurface + AsRef<Surface>, W: io::Write> {
     pub surface: S,
     writer: Box<W>,
 }
 
-impl<S: FromRawSurface + AsRef<Surface>, W: io::Write> Writer_<S, W> {
+impl<S: FromRawSurface + AsRef<Surface>, W: io::Write> Writer<S, W> {
     extern fn write_cb(writer: *mut c_void, data: *mut c_uchar, length: c_uint) -> cairo_status_t {
         let mut writer: Box<W> = unsafe { Box::from_raw(writer as *mut _) };
         let data = unsafe { slice::from_raw_parts(data, length as usize) };
@@ -161,14 +38,14 @@ impl<S: FromRawSurface + AsRef<Surface>, W: io::Write> Writer_<S, W> {
         result.into()
     }
 
-    pub fn new(constructor: Constructor, width: f64, height: f64, writer: W) -> Writer_<S, W> {
+    pub fn new(constructor: Constructor, width: f64, height: f64, writer: W) -> Writer<S, W> {
         let mut writer = Box::new(writer);
         let writer_ptr = unsafe { mem::transmute(&mut *writer) };
         let surface = unsafe {
             S::from_raw_surface(constructor(Some(Self::write_cb), writer_ptr, width, height))
         };
 
-        Writer_ {
+        Writer {
             surface,
             writer,
         }

--- a/src/support.rs
+++ b/src/support.rs
@@ -51,6 +51,9 @@ impl<S: FromRawSurface + AsRef<Surface>, W: io::Write> Writer<S, W> {
         }
     }
 
+    pub fn writer(&self) -> &W { self.writer.as_ref() }
+    pub fn writer_mut(&mut self) -> &mut W { self.writer.as_mut() }
+
     pub fn finish(self) -> W {
         let surface = self.surface;
         surface.as_ref().finish();

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2016, The Gtk-rs Project Developers.
+// Copyright 2018-2019, The Gtk-rs Project Developers.
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -151,6 +151,9 @@ impl<W: io::Write> Writer<W> {
         Writer { writer }
     }
 
+    pub fn writer(&self) -> &W { self.writer.writer() }
+    pub fn writer_mut(&mut self) -> &mut W { self.writer.writer_mut() }
+
     pub fn finish(self) -> W {
         self.writer.finish()
     }
@@ -173,6 +176,12 @@ impl<W: io::Write> AsRef<File> for Writer<W> {
 impl<W: io::Write> AsRef<Surface> for Writer<W> {
     fn as_ref(&self) -> &Surface {
         &self.writer.surface.as_ref()
+    }
+}
+
+impl<W: io::Write + AsRef<[u8]>> AsRef<[u8]> for Writer<W> {
+    fn as_ref(&self) -> &[u8] {
+        &self.writer.writer().as_ref()
     }
 }
 

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -36,6 +36,7 @@ pub fn version_to_string(version: SvgVersion) -> Option<String> {
     }
 }
 
+/// An SVG surface that writes to a file
 pub struct File {
     inner: Surface
 }
@@ -130,6 +131,14 @@ impl FromGlibPtrFull<*mut ffi::cairo_surface_t> for File {
 }
 
 
+/// An SVG surface that writes to a generic `io::Write` type (owning variant)
+///
+/// The `Writer` takes ownership of the write object.
+/// Once you're done using the surface, you can obtain the write object
+/// back using the `finish()` method.
+///
+/// If you would like the surface to reference the write object
+/// instead, use `RefWriter`.
 pub struct Writer<W: io::Write> {
     writer: support::Writer<File, W>,
 }
@@ -179,6 +188,13 @@ impl<'a, W: io::Write> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Writer<W> {
 }
 
 
+/// An SVG surface that writes to a generic `io::Write` type (referencing variant)
+///
+/// The `RefWriter` references the write object,
+/// which is why a lifetime parameter is required.
+///
+/// If you would like the surface to own the write object
+/// instead, use `Writer`.
 pub struct RefWriter<'w, W: io::Write + 'w> {
     writer: support::RefWriter<'w, File, W>,
 }

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -29,10 +29,10 @@ pub fn get_versions() -> Vec<SvgVersion> {
     vers_slice.iter().map(|v| SvgVersion::from(*v)).collect()
 }
 
-pub fn version_to_string(version: SvgVersion) -> Option<String> {
+pub fn version_to_string(version: SvgVersion) -> Option<&'static str> {
     unsafe {
         let res = ffi::cairo_svg_version_to_string(version.into());
-        res.as_ref().and_then(|cstr| CStr::from_ptr(cstr as _).to_str().ok()).map(String::from)
+        res.as_ref().and_then(|cstr| CStr::from_ptr(cstr as _).to_str().ok())
     }
 }
 


### PR DESCRIPTION
Finalized the refactor and added remaining bindings for those three surface types.

Two things I'm not sure about:
- Noticed copyrights were off, fixed it, hopefully correctly.
- `add_outline()` in PDF uses bit flags. I just added integer constants that can be or'd. I thought bringing in the bitflags crate might not be appropriate.

Sorry for such a large diff.
