### PR TITLE
Set PKG_CONFIG_PATH in macOS build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,6 @@ addons:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gtk+3 cairo atk; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig:/usr/local/opt/libffi/lib/pkgconfig;
-    fi
 script:
   - rustc --version
   - cargo doc --features "dox,embed-lgpl-docs"


### PR DESCRIPTION
This is a... speculative patch. It seems to _work_, but I don't feel great about it. I'm out of my depth here so I'm not really sure what the best approach would be, but this should at least get the crate to build for the 95+% of macOS users with homebrew.

I am *very* open to suggestions for how to do this more cleanly.