### PR TITLE
Make winapi optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ default = ["use_glib"]
 xcb = ["cairo-sys-rs/xcb"]
 xlib = ["cairo-sys-rs/xlib"]
 dox = ["cairo-sys-rs/dox", "glib/dox"]
+win32-surface = ["cairo-sys-rs/win32-surface"]
 
 [build-dependencies.gtk-rs-lgpl-docs]
 version = "0.1.8"

--- a/cairo-sys-rs/Cargo.toml
+++ b/cairo-sys-rs/Cargo.toml
@@ -24,6 +24,7 @@ svg = []
 ps = []
 xcb = []
 use_glib = ["glib-sys"]
+win32-surface = ["winapi"]
 
 [dependencies]
 libc = "0.2"
@@ -38,7 +39,7 @@ version = "2.16"
 features = ["xlib"]
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.2", features = ["windef"] }
+winapi = { version = "0.3.2", features = ["windef"], optional = true }
 
 [build-dependencies]
 pkg-config = "0.3.7"

--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -13,15 +13,15 @@ extern crate glib_sys as glib_ffi;
 #[cfg(any(feature = "xlib", feature = "dox"))]
 extern crate x11;
 
-#[cfg(windows)]
+#[cfg(feature = "win32-surface")]
 extern crate winapi as winapi_orig;
 
-#[cfg(windows)]
+#[cfg(feature = "win32-surface")]
 pub mod winapi {
     pub use winapi_orig::shared::windef::HDC;
 }
 
-#[cfg(all(not(windows), feature = "dox"))]
+#[cfg(all(feature = "dox", not(feature = "win32-surface")))]
 pub mod winapi {
    use libc::c_void;
 
@@ -795,28 +795,28 @@ extern "C" {
     pub fn cairo_xlib_device_debug_set_precision(device: *mut cairo_device_t, precision: c_int);
 
     // CAIRO WINDOWS SURFACE
-    #[cfg(any(windows, feature = "dox"))]
+    #[cfg(any(feature = "win32-surface", feature = "dox"))]
     pub fn cairo_win32_surface_create(hdc: winapi::HDC) -> *mut cairo_surface_t;
-    #[cfg(any(all(windows, feature = "v1_14"), feature = "dox"))]
+    #[cfg(all(feature = "v1_14", any(feature = "win32-surface", feature = "dox")))]
     pub fn cairo_win32_surface_create_with_format(hdc: winapi::HDC,
                                                   format: cairo_format_t)
                                                   -> *mut cairo_surface_t;
-    #[cfg(any(windows, feature = "dox"))]
+    #[cfg(any(feature = "win32-surface", feature = "dox"))]
     pub fn cairo_win32_surface_create_with_dib(format: cairo_format_t,
                                                width: c_int,
                                                height: c_int)
                                                -> *mut cairo_surface_t;
-    #[cfg(any(windows, feature = "dox"))]
+    #[cfg(any(feature = "win32-surface", feature = "dox"))]
     pub fn cairo_win32_surface_create_with_ddb(hdc: winapi::HDC,
                                                format: cairo_format_t,
                                                width: c_int,
                                                height: c_int)
                                                -> *mut cairo_surface_t;
-    #[cfg(any(windows, feature = "dox"))]
+    #[cfg(any(feature = "win32-surface", feature = "dox"))]
     pub fn cairo_win32_printing_surface_create(hdc: winapi::HDC) -> *mut cairo_surface_t;
-    #[cfg(any(windows, feature = "dox"))]
+    #[cfg(any(feature = "win32-surface", feature = "dox"))]
     pub fn cairo_win32_surface_get_dc(surface: *mut cairo_surface_t) -> winapi::HDC;
-    #[cfg(any(windows, feature = "dox"))]
+    #[cfg(any(feature = "win32-surface", feature = "dox"))]
     pub fn cairo_win32_surface_get_image(surface: *mut cairo_surface_t) -> *mut cairo_surface_t;
 
     #[cfg(any(target_os = "macos", target_os = "ios", feature = "dox"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,8 +161,8 @@ mod quartz_surface;
 #[cfg(any(target_os = "macos", target_os = "ios", feature = "dox"))]
 pub use quartz_surface::QuartzSurface;
 
-#[cfg(any(windows, feature = "dox"))]
+#[cfg(any(all(windows, feature = "win32-surface"), feature = "dox"))]
 mod win32_surface;
 
-#[cfg(any(windows, feature = "dox"))]
+#[cfg(any(all(windows, feature = "win32-surface"), feature = "dox"))]
 pub use win32_surface::Win32Surface;


### PR DESCRIPTION
Currently, the `winapi` crate is mandatory. But it's very big (100MB). This patch makes it optional by introducing the `win32-surface` feature.