### PR TITLE
cairo-sys: align win32-surface feature gates with those in cairo

### DIFF
--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -13,10 +13,10 @@ extern crate glib_sys as glib_ffi;
 #[cfg(any(feature = "xlib", feature = "dox"))]
 extern crate x11;
 
-#[cfg(feature = "win32-surface")]
+#[cfg(all(windows, feature = "win32-surface"))]
 extern crate winapi as winapi_orig;
 
-#[cfg(feature = "win32-surface")]
+#[cfg(all(windows, feature = "win32-surface"))]
 pub mod winapi {
     pub use winapi_orig::shared::windef::HDC;
 }
@@ -795,28 +795,28 @@ extern "C" {
     pub fn cairo_xlib_device_debug_set_precision(device: *mut cairo_device_t, precision: c_int);
 
     // CAIRO WINDOWS SURFACE
-    #[cfg(any(feature = "win32-surface", feature = "dox"))]
+    #[cfg(any(all(windows, feature = "win32-surface"), feature = "dox"))]
     pub fn cairo_win32_surface_create(hdc: winapi::HDC) -> *mut cairo_surface_t;
-    #[cfg(all(feature = "v1_14", any(feature = "win32-surface", feature = "dox")))]
+    #[cfg(any(all(windows, feature = "win32-surface", feature = "v1_14"), feature = "dox"))]
     pub fn cairo_win32_surface_create_with_format(hdc: winapi::HDC,
                                                   format: cairo_format_t)
                                                   -> *mut cairo_surface_t;
-    #[cfg(any(feature = "win32-surface", feature = "dox"))]
+    #[cfg(any(all(windows, feature = "win32-surface"), feature = "dox"))]
     pub fn cairo_win32_surface_create_with_dib(format: cairo_format_t,
                                                width: c_int,
                                                height: c_int)
                                                -> *mut cairo_surface_t;
-    #[cfg(any(feature = "win32-surface", feature = "dox"))]
+    #[cfg(any(all(windows, feature = "win32-surface"), feature = "dox"))]
     pub fn cairo_win32_surface_create_with_ddb(hdc: winapi::HDC,
                                                format: cairo_format_t,
                                                width: c_int,
                                                height: c_int)
                                                -> *mut cairo_surface_t;
-    #[cfg(any(feature = "win32-surface", feature = "dox"))]
+    #[cfg(any(all(windows, feature = "win32-surface"), feature = "dox"))]
     pub fn cairo_win32_printing_surface_create(hdc: winapi::HDC) -> *mut cairo_surface_t;
-    #[cfg(any(feature = "win32-surface", feature = "dox"))]
+    #[cfg(any(all(windows, feature = "win32-surface"), feature = "dox"))]
     pub fn cairo_win32_surface_get_dc(surface: *mut cairo_surface_t) -> winapi::HDC;
-    #[cfg(any(feature = "win32-surface", feature = "dox"))]
+    #[cfg(any(all(windows, feature = "win32-surface"), feature = "dox"))]
     pub fn cairo_win32_surface_get_image(surface: *mut cairo_surface_t) -> *mut cairo_surface_t;
 
     #[cfg(any(target_os = "macos", target_os = "ios", feature = "dox"))]


### PR DESCRIPTION
fixes error:

```
error[E0425]: cannot find function `cairo_win32_surface_create_with_format` in module `ffi`

  --> src/win32_surface.rs:50:38
   |
50 |             Self::from_raw_full(ffi::cairo_win32_surface_create_with_format(

   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a function with a similar name exists: `cairo_win32_surface_create_with_ddb`
```

when running:

```
cargo doc --features "dox"
```