### PR TITLE
Prevent linking libraries with "dox" feature to avoid documentation f…

### DIFF
--- a/cairo-sys-rs/build.rs
+++ b/cairo-sys-rs/build.rs
@@ -1,11 +1,21 @@
+#[cfg(not(feature = "dox"))]
 extern crate pkg_config;
 
+#[cfg(not(feature = "dox"))]
 use pkg_config::{Config, Error};
+#[cfg(not(feature = "dox"))]
 use std::env;
+#[cfg(not(feature = "dox"))]
 use std::io;
+#[cfg(not(feature = "dox"))]
 use std::io::prelude::*;
+#[cfg(not(feature = "dox"))]
 use std::process;
 
+#[cfg(feature = "dox")]
+fn main() {} // prevent linking libraries to avoid documentation failure
+
+#[cfg(not(feature = "dox"))]
 fn main() {
     if cfg!(feature = "use_glib") {
         // This include cairo linker flags
@@ -21,6 +31,7 @@ fn main() {
     }
 }
 
+#[cfg(not(feature = "dox"))]
 fn find(package_name: &str, shared_libs: &[&str]) -> Result<(), Error> {
     let version = "1.12";
 


### PR DESCRIPTION
…ailure

Found in https://github.com/gtk-rs/glib/issues/582

It seems single sys crate in gtk-rs, that don't have these changes.

cc @GuillaumeGomez, @sdroege 