### PR TITLE
add cairo_surface_create_for_rectangle()

### DIFF
--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -958,6 +958,13 @@ extern "C" {
         width: c_int,
         height: c_int,
     ) -> *mut cairo_surface_t;
+    pub fn cairo_surface_create_for_rectangle(
+        surface: *mut cairo_surface_t,
+	x: c_double,
+	y: c_double,
+	width: c_double,
+	height: c_double,
+    ) -> *mut cairo_surface_t;
     pub fn cairo_surface_get_mime_data(
         surface: *mut cairo_surface_t,
         mime_type: *const c_char,

--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -960,10 +960,10 @@ extern "C" {
     ) -> *mut cairo_surface_t;
     pub fn cairo_surface_create_for_rectangle(
         surface: *mut cairo_surface_t,
-	x: c_double,
-	y: c_double,
-	width: c_double,
-	height: c_double,
+        x: c_double,
+        y: c_double,
+        width: c_double,
+        height: c_double,
     ) -> *mut cairo_surface_t;
     pub fn cairo_surface_get_mime_data(
         surface: *mut cairo_surface_t,

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -15,8 +15,8 @@ use ffi;
 use glib::translate::*;
 
 use image_surface::ImageSurface;
-use rectangle_int::RectangleInt;
 use rectangle::Rectangle;
+use rectangle_int::RectangleInt;
 
 #[derive(Debug)]
 pub struct Surface(*mut ffi::cairo_surface_t, bool);
@@ -59,17 +59,14 @@ impl Surface {
         }
     }
 
-    pub fn create_for_rectangle(
-        &self,
-	bounds: Rectangle,
-    ) -> Result<Surface, Status> {
+    pub fn create_for_rectangle(&self, bounds: Rectangle) -> Result<Surface, Status> {
         unsafe {
             Self::from_raw_full(ffi::cairo_surface_create_for_rectangle(
                 self.0,
-		bounds.x,
-		bounds.y,
-		bounds.width,
-		bounds.height,
+                bounds.x,
+                bounds.y,
+                bounds.width,
+                bounds.height,
             ))
         }
     }

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -16,6 +16,7 @@ use glib::translate::*;
 
 use image_surface::ImageSurface;
 use rectangle_int::RectangleInt;
+use rectangle::Rectangle;
 
 #[derive(Debug)]
 pub struct Surface(*mut ffi::cairo_surface_t, bool);
@@ -54,6 +55,21 @@ impl Surface {
                 content.into(),
                 width,
                 height,
+            ))
+        }
+    }
+
+    pub fn create_for_rectangle(
+        &self,
+	bounds: Rectangle,
+    ) -> Result<Surface, Status> {
+        unsafe {
+            Self::from_raw_full(ffi::cairo_surface_create_for_rectangle(
+                self.0,
+		bounds.x,
+		bounds.y,
+		bounds.width,
+		bounds.height,
             ))
         }
     }


### PR DESCRIPTION
add interface for cairo_surface_create_for_rectangle (creates subsurface of an existing surface).