### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ git = "https://github.com/gtk-rs/sys"
 [dependencies]
 libc = "0.2"
 bitflags = "1.0"
+thiserror = "1.0.10"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,13 +3,14 @@
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
 use enums::Status;
-use std::error::Error;
-use std::fmt;
 use std::io;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum BorrowError {
+    #[error("BorrowError::Cairo({0})")]
     Cairo(Status),
+    #[error("BorrowError::NonExclusive")]
     NonExclusive,
 }
 
@@ -19,54 +20,16 @@ impl From<Status> for BorrowError {
     }
 }
 
-impl fmt::Display for BorrowError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            BorrowError::Cairo(status) => write!(f, "BorrowError::Cairo({})", status),
-            BorrowError::NonExclusive => write!(f, "BorrowError::NonExclusive"),
-        }
-    }
-}
-
-impl Error for BorrowError {
-    fn description(&self) -> &str {
-        match *self {
-            BorrowError::Cairo(_) => "BorrowError::Cairo",
-            BorrowError::NonExclusive => "BorrowError::NonExclusive",
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn Error> {
-        None
-    }
-}
-
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum IoError {
+    #[error("IoError::Cairo({0}")]
     Cairo(Status),
-    Io(io::Error),
+    #[error("IoError::Io({0}")]
+    Io(#[from] io::Error),
 }
 
 impl From<Status> for IoError {
     fn from(status: Status) -> Self {
         IoError::Cairo(status)
-    }
-}
-
-impl fmt::Display for IoError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            IoError::Cairo(status) => write!(f, "IoError::Cairo({})", status),
-            IoError::Io(ref e) => write!(f, "IoError::Io({})", e),
-        }
-    }
-}
-
-impl Error for IoError {
-    fn cause(&self) -> Option<&dyn Error> {
-        match *self {
-            IoError::Cairo(_) => None,
-            IoError::Io(ref e) => Some(e),
-        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,9 +8,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum BorrowError {
-    #[error("BorrowError::Cairo({0})")]
+    #[error("Failed to borrow with Cairo error:{0}")]
     Cairo(Status),
-    #[error("BorrowError::NonExclusive")]
+    #[error("Can't get exclusive access")]
     NonExclusive,
 }
 
@@ -22,9 +22,9 @@ impl From<Status> for BorrowError {
 
 #[derive(Error, Debug)]
 pub enum IoError {
-    #[error("IoError::Cairo({0}")]
+    #[error("Cairo error: {0}")]
     Cairo(Status),
-    #[error("IoError::Io({0}")]
+    #[error("IO error: {0}")]
     Io(#[from] io::Error),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,13 +63,6 @@ impl fmt::Display for IoError {
 }
 
 impl Error for IoError {
-    fn description(&self) -> &str {
-        match *self {
-            IoError::Cairo(_) => "IoError::Cairo",
-            IoError::Io(ref e) => e.description(),
-        }
-    }
-
     fn cause(&self) -> Option<&dyn Error> {
         match *self {
             IoError::Cairo(_) => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@
 
 extern crate cairo_sys as ffi;
 extern crate libc;
+extern crate thiserror;
 
 #[macro_use]
 extern crate bitflags;

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -488,6 +488,12 @@ impl Mesh {
     }
 }
 
+impl Default for Mesh {
+    fn default() -> Mesh {
+        Mesh::new()
+    }
+}
+
 #[test]
 fn try_from() {
     let linear = LinearGradient::new(0., 0., 1., 1.);

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -224,7 +224,7 @@ impl Surface {
         unsafe {
             ImageSurface::from_raw_full(match extents {
                 Some(ref e) => ffi::cairo_surface_map_to_image(self.to_raw_none(), e.to_raw_none()),
-                None => ffi::cairo_surface_map_to_image(self.to_raw_none(), 0 as *const _),
+                None => ffi::cairo_surface_map_to_image(self.to_raw_none(), std::ptr::null()),
             })
             .map(|s| MappedImageSurface {
                 original_surface: self.clone(),


### PR DESCRIPTION
Fix
```
warning: use of deprecated item 'std::error::Error::description': use the Display impl or to_string()
  --> D:/eap/rust/0/cairo\src\error.rs:69:37
   |
69 |             IoError::Io(ref e) => e.description(),
   |                                     ^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```

cc @GuillaumeGomez , @sdroege 