### PR TITLE
Update for new from_glib_borrow signature

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -11,30 +11,31 @@ use ffi;
 use glib::translate::*;
 use recording_surface::RecordingSurface;
 use std::fmt;
+use std::ptr;
 use surface::Surface;
 
 #[derive(Debug)]
-pub struct Device(*mut ffi::cairo_device_t, bool);
+pub struct Device(ptr::NonNull<ffi::cairo_device_t>);
 
 impl Device {
     pub unsafe fn from_raw_none(ptr: *mut ffi::cairo_device_t) -> Device {
         assert!(!ptr.is_null());
         ffi::cairo_device_reference(ptr);
-        Device(ptr, false)
+        Device(ptr::NonNull::new_unchecked(ptr))
     }
 
-    pub unsafe fn from_raw_borrow(ptr: *mut ffi::cairo_device_t) -> Device {
+    pub unsafe fn from_raw_borrow(ptr: *mut ffi::cairo_device_t) -> ::Borrowed<Device> {
         assert!(!ptr.is_null());
-        Device(ptr, true)
+        ::Borrowed::new(Device(ptr::NonNull::new_unchecked(ptr)))
     }
 
     pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_device_t) -> Device {
         assert!(!ptr.is_null());
-        Device(ptr, false)
+        Device(ptr::NonNull::new_unchecked(ptr))
     }
 
     pub fn to_raw_none(&self) -> *mut ffi::cairo_device_t {
-        self.0
+        self.0.as_ptr()
     }
 
     pub fn create<P: AsRef<Path>>(filename: P) -> Option<Device> {
@@ -279,7 +280,7 @@ impl FromGlibPtrNone<*mut ffi::cairo_device_t> for Device {
 #[cfg(feature = "use_glib")]
 impl FromGlibPtrBorrow<*mut ffi::cairo_device_t> for Device {
     #[inline]
-    unsafe fn from_glib_borrow(ptr: *mut ffi::cairo_device_t) -> Device {
+    unsafe fn from_glib_borrow(ptr: *mut ffi::cairo_device_t) -> ::Borrowed<Device> {
         Self::from_raw_borrow(ptr)
     }
 }
@@ -301,16 +302,14 @@ gvalue_impl!(
 
 impl Clone for Device {
     fn clone(&self) -> Device {
-        unsafe { Self::from_raw_none(ffi::cairo_device_reference(self.0)) }
+        unsafe { Self::from_raw_none(ffi::cairo_device_reference(self.0.as_ptr())) }
     }
 }
 
 impl Drop for Device {
     fn drop(&mut self) {
-        if !self.1 {
-            unsafe {
-                ffi::cairo_device_destroy(self.0);
-            }
+        unsafe {
+            ffi::cairo_device_destroy(self.0.as_ptr());
         }
     }
 }

--- a/src/font/font_face.rs
+++ b/src/font/font_face.rs
@@ -3,6 +3,8 @@ use ffi;
 use glib::translate::*;
 use libc::c_char;
 use std::ffi::{CStr, CString};
+#[cfg(not(feature = "use_glib"))]
+use std::ptr;
 
 use enums::{FontSlant, FontType, FontWeight, FtSynthesize, Status};
 
@@ -20,7 +22,7 @@ glib_wrapper! {
 
 #[cfg(not(feature = "use_glib"))]
 #[derive(Debug)]
-pub struct FontFace(*mut ffi::cairo_font_face_t);
+pub struct FontFace(ptr::NonNull<ffi::cairo_font_face_t>);
 
 impl FontFace {
     pub fn toy_create(family: &str, slant: FontSlant, weight: FontWeight) -> FontFace {
@@ -44,7 +46,7 @@ impl FontFace {
     #[cfg(not(feature = "use_glib"))]
     pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_font_face_t) -> FontFace {
         assert!(!ptr.is_null());
-        FontFace(ptr)
+        FontFace(ptr::NonNull::new_unchecked(ptr))
     }
 
     #[cfg(feature = "use_glib")]
@@ -55,7 +57,7 @@ impl FontFace {
     #[cfg(not(feature = "use_glib"))]
     pub unsafe fn from_raw_none(ptr: *mut ffi::cairo_font_face_t) -> FontFace {
         assert!(!ptr.is_null());
-        FontFace(ptr)
+        FontFace(ptr::NonNull::new_unchecked(ptr))
     }
 
     #[cfg(feature = "use_glib")]
@@ -65,7 +67,7 @@ impl FontFace {
 
     #[cfg(not(feature = "use_glib"))]
     pub fn to_raw_none(&self) -> *mut ffi::cairo_font_face_t {
-        self.0
+        self.0.as_ptr()
     }
 
     pub fn toy_get_family(&self) -> Option<String> {

--- a/src/font/font_options.rs
+++ b/src/font/font_options.rs
@@ -8,6 +8,8 @@ use std::hash;
 use font::font_face::to_optional_string;
 #[cfg(any(feature = "v1_16", feature = "dox"))]
 use std::ffi::CString;
+#[cfg(not(feature = "use_glib"))]
+use std::ptr;
 
 use enums::{Antialias, HintMetrics, HintStyle, Status, SubpixelOrder};
 
@@ -30,7 +32,7 @@ glib_wrapper! {
 
 #[cfg(not(feature = "use_glib"))]
 #[derive(Debug)]
-pub struct FontOptions(*mut ffi::cairo_font_options_t);
+pub struct FontOptions(ptr::NonNull<ffi::cairo_font_options_t>);
 
 impl FontOptions {
     pub fn new() -> FontOptions {
@@ -48,7 +50,7 @@ impl FontOptions {
     #[cfg(not(feature = "use_glib"))]
     pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_font_options_t) -> FontOptions {
         assert!(!ptr.is_null());
-        FontOptions(ptr)
+        FontOptions(ptr::NonNull::new_unchecked(ptr))
     }
 
     #[cfg(feature = "use_glib")]
@@ -58,7 +60,7 @@ impl FontOptions {
 
     #[cfg(not(feature = "use_glib"))]
     pub fn to_raw_none(&self) -> *mut ffi::cairo_font_options_t {
-        self.0
+        self.0.as_ptr()
     }
 
     pub fn ensure_status(&self) {

--- a/src/font/scaled_font.rs
+++ b/src/font/scaled_font.rs
@@ -24,7 +24,7 @@ glib_wrapper! {
 
 #[cfg(not(feature = "use_glib"))]
 #[derive(Debug)]
-pub struct ScaledFont(*mut ffi::cairo_scaled_font_t);
+pub struct ScaledFont(ptr::NonNull<ffi::cairo_scaled_font_t>);
 
 impl ScaledFont {
     pub fn new(
@@ -52,13 +52,13 @@ impl ScaledFont {
 
     #[cfg(not(feature = "use_glib"))]
     pub fn to_raw_none(&self) -> *mut ffi::cairo_scaled_font_t {
-        self.0
+        self.0.as_ptr()
     }
 
     #[cfg(not(feature = "use_glib"))]
     pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_scaled_font_t) -> ScaledFont {
         assert!(!ptr.is_null());
-        ScaledFont(ptr)
+        ScaledFont(ptr::NonNull::new_unchecked(ptr))
     }
 
     #[cfg(feature = "use_glib")]
@@ -75,7 +75,7 @@ impl ScaledFont {
     pub unsafe fn from_raw_none(ptr: *mut ffi::cairo_scaled_font_t) -> ScaledFont {
         assert!(!ptr.is_null());
         ffi::cairo_scaled_font_reference(ptr);
-        ScaledFont(ptr)
+        ScaledFont(ptr::NonNull::new_unchecked(ptr))
     }
 
     pub fn ensure_status(&self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,3 +207,53 @@ mod win32_surface;
 
 #[cfg(any(all(windows, feature = "win32-surface"), feature = "dox"))]
 pub use win32_surface::Win32Surface;
+
+#[cfg(not(feature = "use_glib"))]
+mod borrowed {
+    use std::mem;
+
+    /// Wrapper around values representing borrowed C memory.
+    ///
+    /// This is returned by `from_glib_borrow()` and ensures that the wrapped value
+    /// is never dropped when going out of scope.
+    ///
+    /// Borrowed values must never be passed by value or mutable reference to safe Rust code and must
+    /// not leave the C scope in which they are valid.
+    #[derive(Debug)]
+    pub struct Borrowed<T>(mem::ManuallyDrop<T>);
+
+    impl<T> Borrowed<T> {
+        /// Creates a new borrowed value.
+        pub fn new(val: T) -> Self {
+            Self(mem::ManuallyDrop::new(val))
+        }
+
+        /// Extracts the contained value.
+        ///
+        /// The returned value must never be dropped and instead has to be passed to `mem::forget()` or
+        /// be directly wrapped in `mem::ManuallyDrop` or another `Borrowed` wrapper.
+        pub unsafe fn into_inner(self) -> T {
+            mem::ManuallyDrop::into_inner(self.0)
+        }
+    }
+
+    impl<T> AsRef<T> for Borrowed<T> {
+        fn as_ref(&self) -> &T {
+            &*self.0
+        }
+    }
+
+    impl<T> std::ops::Deref for Borrowed<T> {
+        type Target = T;
+
+        fn deref(&self) -> &T {
+            &*self.0
+        }
+    }
+}
+
+#[cfg(not(feature = "use_glib"))]
+pub use borrowed::Borrowed;
+
+#[cfg(feature = "use_glib")]
+pub(crate) use glib::translate::Borrowed;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -6,14 +6,15 @@ use enums::{PathDataType, Status};
 use ffi;
 use ffi::cairo_path_t;
 use std::fmt;
+use std::ptr;
 use std::iter::Iterator;
 
 #[derive(Debug)]
-pub struct Path(*mut cairo_path_t);
+pub struct Path(ptr::NonNull<cairo_path_t>);
 
 impl Path {
     pub fn as_ptr(&self) -> *mut cairo_path_t {
-        self.0
+        self.0.as_ptr()
     }
 
     pub fn ensure_status(&self) {
@@ -24,7 +25,8 @@ impl Path {
     }
 
     pub unsafe fn from_raw_full(pointer: *mut cairo_path_t) -> Path {
-        Path(pointer)
+        assert!(!pointer.is_null());
+        Path(ptr::NonNull::new_unchecked(pointer))
     }
 
     pub fn iter(&self) -> PathSegments {

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -58,8 +58,8 @@ impl FromGlibPtrNone<*const ffi::cairo_rectangle_t> for Rectangle {
 #[cfg(feature = "use_glib")]
 #[doc(hidden)]
 impl FromGlibPtrBorrow<*mut ffi::cairo_rectangle_t> for Rectangle {
-    unsafe fn from_glib_borrow(ptr: *mut ffi::cairo_rectangle_t) -> Self {
-        *(ptr as *mut Rectangle)
+    unsafe fn from_glib_borrow(ptr: *mut ffi::cairo_rectangle_t) -> ::Borrowed<Self> {
+        ::Borrowed::new(*(ptr as *mut Rectangle))
     }
 }
 

--- a/src/rectangle_int.rs
+++ b/src/rectangle_int.rs
@@ -58,8 +58,8 @@ impl FromGlibPtrNone<*const ffi::cairo_rectangle_int_t> for RectangleInt {
 #[cfg(feature = "use_glib")]
 #[doc(hidden)]
 impl FromGlibPtrBorrow<*mut ffi::cairo_rectangle_int_t> for RectangleInt {
-    unsafe fn from_glib_borrow(ptr: *mut ffi::cairo_rectangle_int_t) -> Self {
-        *(ptr as *mut RectangleInt)
+    unsafe fn from_glib_borrow(ptr: *mut ffi::cairo_rectangle_int_t) -> ::Borrowed<Self> {
+        ::Borrowed::new(*(ptr as *mut RectangleInt))
     }
 }
 

--- a/src/region.rs
+++ b/src/region.rs
@@ -7,12 +7,13 @@ use ffi;
 #[cfg(feature = "use_glib")]
 use glib::translate::*;
 use std::fmt;
+use std::ptr;
 use RectangleInt;
 
 use ffi::cairo_region_t;
 
 #[derive(Debug)]
-pub struct Region(*mut cairo_region_t, bool);
+pub struct Region(ptr::NonNull<cairo_region_t>);
 
 #[cfg(feature = "use_glib")]
 #[doc(hidden)]
@@ -21,12 +22,12 @@ impl<'a> ToGlibPtr<'a, *mut ffi::cairo_region_t> for &'a Region {
 
     #[inline]
     fn to_glib_none(&self) -> Stash<'a, *mut ffi::cairo_region_t, &'a Region> {
-        Stash(self.0, *self)
+        Stash(self.0.as_ptr(), *self)
     }
 
     #[inline]
     fn to_glib_full(&self) -> *mut ffi::cairo_region_t {
-        unsafe { ffi::cairo_region_reference(self.0) }
+        unsafe { ffi::cairo_region_reference(self.0.as_ptr()) }
     }
 }
 
@@ -39,7 +40,7 @@ impl<'a> ToGlibPtrMut<'a, *mut ffi::cairo_region_t> for Region {
     // references here
     #[inline]
     fn to_glib_none_mut(&'a mut self) -> StashMut<'a, *mut ffi::cairo_region_t, Self> {
-        StashMut(self.0, self)
+        StashMut(self.0.as_ptr(), self)
     }
 }
 
@@ -56,7 +57,7 @@ impl FromGlibPtrNone<*mut ffi::cairo_region_t> for Region {
 #[doc(hidden)]
 impl FromGlibPtrBorrow<*mut ffi::cairo_region_t> for Region {
     #[inline]
-    unsafe fn from_glib_borrow(ptr: *mut ffi::cairo_region_t) -> Region {
+    unsafe fn from_glib_borrow(ptr: *mut ffi::cairo_region_t) -> ::Borrowed<Region> {
         Self::from_raw_borrow(ptr)
     }
 }
@@ -85,17 +86,15 @@ impl Clone for Region {
 
 impl Drop for Region {
     fn drop(&mut self) {
-        if !self.1 {
-            unsafe {
-                ffi::cairo_region_destroy(self.0);
-            }
+        unsafe {
+            ffi::cairo_region_destroy(self.0.as_ptr());
         }
     }
 }
 
 impl PartialEq for Region {
     fn eq(&self, other: &Region) -> bool {
-        unsafe { ffi::cairo_region_equal(self.0, other.0).as_bool() }
+        unsafe { ffi::cairo_region_equal(self.0.as_ptr(), other.0.as_ptr()).as_bool() }
     }
 }
 
@@ -106,23 +105,23 @@ impl Region {
     pub unsafe fn from_raw_none(ptr: *mut ffi::cairo_region_t) -> Region {
         assert!(!ptr.is_null());
         ffi::cairo_region_reference(ptr);
-        Region(ptr, false)
+        Region(ptr::NonNull::new_unchecked(ptr))
     }
 
     #[inline]
-    pub unsafe fn from_raw_borrow(ptr: *mut ffi::cairo_region_t) -> Region {
+    pub unsafe fn from_raw_borrow(ptr: *mut ffi::cairo_region_t) -> ::Borrowed<Region> {
         assert!(!ptr.is_null());
-        Region(ptr, true)
+        ::Borrowed::new(Region(ptr::NonNull::new_unchecked(ptr)))
     }
 
     #[inline]
     pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_region_t) -> Region {
         assert!(!ptr.is_null());
-        Region(ptr, false)
+        Region(ptr::NonNull::new_unchecked(ptr))
     }
 
     pub fn to_raw_none(&self) -> *mut ffi::cairo_region_t {
-        self.0
+        self.0.as_ptr()
     }
 
     pub fn create() -> Region {
@@ -143,97 +142,107 @@ impl Region {
     }
 
     pub fn copy(&self) -> Region {
-        unsafe { Self::from_raw_full(ffi::cairo_region_copy(self.0)) }
+        unsafe { Self::from_raw_full(ffi::cairo_region_copy(self.0.as_ptr())) }
     }
 
     pub fn status(&self) -> Status {
-        unsafe { Status::from(ffi::cairo_region_status(self.0)) }
+        unsafe { Status::from(ffi::cairo_region_status(self.0.as_ptr())) }
     }
 
     pub fn get_extents(&self, rectangle: &mut RectangleInt) {
-        unsafe { ffi::cairo_region_get_extents(self.0, rectangle.to_raw_none()) }
+        unsafe { ffi::cairo_region_get_extents(self.0.as_ptr(), rectangle.to_raw_none()) }
     }
 
     pub fn num_rectangles(&self) -> i32 {
-        unsafe { ffi::cairo_region_num_rectangles(self.0) }
+        unsafe { ffi::cairo_region_num_rectangles(self.0.as_ptr()) }
     }
 
     pub fn get_rectangle(&self, nth: i32) -> RectangleInt {
         unsafe {
             let rectangle: RectangleInt = ::std::mem::zeroed();
-            ffi::cairo_region_get_rectangle(self.0, nth, rectangle.to_raw_none());
+            ffi::cairo_region_get_rectangle(self.0.as_ptr(), nth, rectangle.to_raw_none());
             rectangle
         }
     }
 
     pub fn is_empty(&self) -> bool {
-        unsafe { ffi::cairo_region_is_empty(self.0).as_bool() }
+        unsafe { ffi::cairo_region_is_empty(self.0.as_ptr()).as_bool() }
     }
 
     pub fn contains_point(&self, x: i32, y: i32) -> bool {
-        unsafe { ffi::cairo_region_contains_point(self.0, x, y).as_bool() }
+        unsafe { ffi::cairo_region_contains_point(self.0.as_ptr(), x, y).as_bool() }
     }
 
     pub fn contains_rectangle(&self, rectangle: &RectangleInt) -> RegionOverlap {
         unsafe {
             RegionOverlap::from(ffi::cairo_region_contains_rectangle(
-                self.0,
+                self.0.as_ptr(),
                 rectangle.to_raw_none(),
             ))
         }
     }
 
     pub fn translate(&self, dx: i32, dy: i32) {
-        unsafe { ffi::cairo_region_translate(self.0, dx, dy) }
+        unsafe { ffi::cairo_region_translate(self.0.as_ptr(), dx, dy) }
     }
 
     pub fn intersect(&self, other: &Region) -> Status {
-        unsafe { Status::from(ffi::cairo_region_intersect(self.0, other.0)) }
+        unsafe {
+            Status::from(ffi::cairo_region_intersect(
+                self.0.as_ptr(),
+                other.0.as_ptr(),
+            ))
+        }
     }
 
     pub fn intersect_rectangle(&self, rectangle: &RectangleInt) -> Status {
         unsafe {
             Status::from(ffi::cairo_region_intersect_rectangle(
-                self.0,
+                self.0.as_ptr(),
                 rectangle.to_raw_none(),
             ))
         }
     }
 
     pub fn subtract(&self, other: &Region) -> Status {
-        unsafe { Status::from(ffi::cairo_region_subtract(self.0, other.0)) }
+        unsafe {
+            Status::from(ffi::cairo_region_subtract(
+                self.0.as_ptr(),
+                other.0.as_ptr(),
+            ))
+        }
     }
 
     pub fn subtract_rectangle(&self, rectangle: &RectangleInt) -> Status {
         unsafe {
             Status::from(ffi::cairo_region_subtract_rectangle(
-                self.0,
+                self.0.as_ptr(),
                 rectangle.to_raw_none(),
             ))
         }
     }
 
     pub fn union(&self, other: &Region) -> Status {
-        unsafe { Status::from(ffi::cairo_region_union(self.0, other.0)) }
+        unsafe { Status::from(ffi::cairo_region_union(self.0.as_ptr(), other.0.as_ptr())) }
     }
 
     pub fn union_rectangle(&self, rectangle: &RectangleInt) -> Status {
         unsafe {
             Status::from(ffi::cairo_region_union_rectangle(
-                self.0,
+                self.0.as_ptr(),
                 rectangle.to_raw_none(),
             ))
         }
     }
 
     pub fn xor(&self, other: &Region) -> Status {
-        unsafe { Status::from(ffi::cairo_region_xor(self.0, other.0)) }
+        unsafe { Status::from(ffi::cairo_region_xor(self.0.as_ptr(), other.0.as_ptr())) }
     }
 
     pub fn xor_rectangle(&self, rectangle: &RectangleInt) -> Status {
         unsafe {
             Status::from(ffi::cairo_region_xor_rectangle(
-                self.0,
+                self.0.as_ptr(),
                 rectangle.to_raw_none(),
             ))
         }

--- a/src/surface_macros.rs
+++ b/src/surface_macros.rs
@@ -52,8 +52,12 @@ macro_rules! declare_surface {
         #[cfg(feature = "use_glib")]
         impl FromGlibPtrBorrow<*mut ffi::cairo_surface_t> for $surf_name {
             #[inline]
-            unsafe fn from_glib_borrow(ptr: *mut ffi::cairo_surface_t) -> $surf_name {
-                Self::try_from(from_glib_borrow::<_, Surface>(ptr)).unwrap()
+            unsafe fn from_glib_borrow(ptr: *mut ffi::cairo_surface_t) -> ::Borrowed<$surf_name> {
+                let surface = from_glib_borrow::<_, Surface>(ptr);
+                let surface = Self::try_from(surface.into_inner())
+                    .map_err(std::mem::forget)
+                    .unwrap();
+                ::Borrowed::new(surface)
             }
         }
 

--- a/src/xcb.rs
+++ b/src/xcb.rs
@@ -9,6 +9,7 @@ use glib::translate::*;
 use std::convert::TryFrom;
 use std::fmt;
 use std::ops::Deref;
+use std::ptr;
 
 use enums::Status;
 use surface::Surface;
@@ -44,26 +45,26 @@ impl fmt::Display for XCBPixmap {
 }
 
 #[derive(Debug)]
-pub struct XCBConnection(pub *mut ffi::xcb_connection_t);
+pub struct XCBConnection(pub ptr::NonNull<ffi::xcb_connection_t>);
 
 impl XCBConnection {
     pub fn to_raw_none(&self) -> *mut ffi::xcb_connection_t {
-        self.0
+        self.0.as_ptr()
     }
 
     pub unsafe fn from_raw_none(ptr: *mut ffi::xcb_connection_t) -> XCBConnection {
         assert!(!ptr.is_null());
-        XCBConnection(ptr)
+        XCBConnection(ptr::NonNull::new_unchecked(ptr))
     }
 
-    pub unsafe fn from_raw_borrow(ptr: *mut ffi::xcb_connection_t) -> XCBConnection {
+    pub unsafe fn from_raw_borrow(ptr: *mut ffi::xcb_connection_t) -> ::Borrowed<XCBConnection> {
         assert!(!ptr.is_null());
-        XCBConnection(ptr)
+        ::Borrowed::new(XCBConnection(ptr::NonNull::new_unchecked(ptr)))
     }
 
     pub unsafe fn from_raw_full(ptr: *mut ffi::xcb_connection_t) -> XCBConnection {
         assert!(!ptr.is_null());
-        XCBConnection(ptr)
+        XCBConnection(ptr::NonNull::new_unchecked(ptr))
     }
 }
 
@@ -88,7 +89,7 @@ impl FromGlibPtrNone<*mut ffi::xcb_connection_t> for XCBConnection {
 #[cfg(feature = "use_glib")]
 impl FromGlibPtrBorrow<*mut ffi::xcb_connection_t> for XCBConnection {
     #[inline]
-    unsafe fn from_glib_borrow(ptr: *mut ffi::xcb_connection_t) -> XCBConnection {
+    unsafe fn from_glib_borrow(ptr: *mut ffi::xcb_connection_t) -> ::Borrowed<XCBConnection> {
         Self::from_raw_borrow(ptr)
     }
 }
@@ -114,28 +115,28 @@ impl fmt::Display for XCBConnection {
 }
 
 #[derive(Debug)]
-pub struct XCBRenderPictFormInfo(pub *mut ffi::xcb_render_pictforminfo_t);
+pub struct XCBRenderPictFormInfo(pub ptr::NonNull<ffi::xcb_render_pictforminfo_t>);
 
 impl XCBRenderPictFormInfo {
     pub fn to_raw_none(&self) -> *mut ffi::xcb_render_pictforminfo_t {
-        self.0
+        self.0.as_ptr()
     }
 
     pub unsafe fn from_raw_none(ptr: *mut ffi::xcb_render_pictforminfo_t) -> XCBRenderPictFormInfo {
         assert!(!ptr.is_null());
-        XCBRenderPictFormInfo(ptr)
+        XCBRenderPictFormInfo(ptr::NonNull::new_unchecked(ptr))
     }
 
     pub unsafe fn from_raw_borrow(
         ptr: *mut ffi::xcb_render_pictforminfo_t,
-    ) -> XCBRenderPictFormInfo {
+    ) -> ::Borrowed<XCBRenderPictFormInfo> {
         assert!(!ptr.is_null());
-        XCBRenderPictFormInfo(ptr)
+        ::Borrowed::new(XCBRenderPictFormInfo(ptr::NonNull::new_unchecked(ptr)))
     }
 
     pub unsafe fn from_raw_full(ptr: *mut ffi::xcb_render_pictforminfo_t) -> XCBRenderPictFormInfo {
         assert!(!ptr.is_null());
-        XCBRenderPictFormInfo(ptr)
+        XCBRenderPictFormInfo(ptr::NonNull::new_unchecked(ptr))
     }
 }
 
@@ -162,7 +163,9 @@ impl FromGlibPtrNone<*mut ffi::xcb_render_pictforminfo_t> for XCBRenderPictFormI
 #[cfg(feature = "use_glib")]
 impl FromGlibPtrBorrow<*mut ffi::xcb_render_pictforminfo_t> for XCBRenderPictFormInfo {
     #[inline]
-    unsafe fn from_glib_borrow(ptr: *mut ffi::xcb_render_pictforminfo_t) -> XCBRenderPictFormInfo {
+    unsafe fn from_glib_borrow(
+        ptr: *mut ffi::xcb_render_pictforminfo_t,
+    ) -> ::Borrowed<XCBRenderPictFormInfo> {
         Self::from_raw_borrow(ptr)
     }
 }
@@ -188,26 +191,26 @@ impl fmt::Display for XCBRenderPictFormInfo {
 }
 
 #[derive(Debug)]
-pub struct XCBScreen(pub *mut ffi::xcb_screen_t);
+pub struct XCBScreen(pub ptr::NonNull<ffi::xcb_screen_t>);
 
 impl XCBScreen {
     pub fn to_raw_none(&self) -> *mut ffi::xcb_screen_t {
-        self.0
+        self.0.as_ptr()
     }
 
     pub unsafe fn from_raw_none(ptr: *mut ffi::xcb_screen_t) -> XCBScreen {
         assert!(!ptr.is_null());
-        XCBScreen(ptr)
+        XCBScreen(ptr::NonNull::new_unchecked(ptr))
     }
 
-    pub unsafe fn from_raw_borrow(ptr: *mut ffi::xcb_screen_t) -> XCBScreen {
+    pub unsafe fn from_raw_borrow(ptr: *mut ffi::xcb_screen_t) -> ::Borrowed<XCBScreen> {
         assert!(!ptr.is_null());
-        XCBScreen(ptr)
+        ::Borrowed::new(XCBScreen(ptr::NonNull::new_unchecked(ptr)))
     }
 
     pub unsafe fn from_raw_full(ptr: *mut ffi::xcb_screen_t) -> XCBScreen {
         assert!(!ptr.is_null());
-        XCBScreen(ptr)
+        XCBScreen(ptr::NonNull::new_unchecked(ptr))
     }
 }
 
@@ -232,7 +235,7 @@ impl FromGlibPtrNone<*mut ffi::xcb_screen_t> for XCBScreen {
 #[cfg(feature = "use_glib")]
 impl FromGlibPtrBorrow<*mut ffi::xcb_screen_t> for XCBScreen {
     #[inline]
-    unsafe fn from_glib_borrow(ptr: *mut ffi::xcb_screen_t) -> XCBScreen {
+    unsafe fn from_glib_borrow(ptr: *mut ffi::xcb_screen_t) -> ::Borrowed<XCBScreen> {
         Self::from_raw_borrow(ptr)
     }
 }
@@ -344,26 +347,26 @@ impl XCBSurface {
 }
 
 #[derive(Debug)]
-pub struct XCBVisualType(pub *mut ffi::xcb_visualtype_t);
+pub struct XCBVisualType(pub ptr::NonNull<ffi::xcb_visualtype_t>);
 
 impl XCBVisualType {
     pub fn to_raw_none(&self) -> *mut ffi::xcb_visualtype_t {
-        self.0
+        self.0.as_ptr()
     }
 
     pub unsafe fn from_raw_none(ptr: *mut ffi::xcb_visualtype_t) -> XCBVisualType {
         assert!(!ptr.is_null());
-        XCBVisualType(ptr)
+        XCBVisualType(ptr::NonNull::new_unchecked(ptr))
     }
 
-    pub unsafe fn from_raw_borrow(ptr: *mut ffi::xcb_visualtype_t) -> XCBVisualType {
+    pub unsafe fn from_raw_borrow(ptr: *mut ffi::xcb_visualtype_t) -> ::Borrowed<XCBVisualType> {
         assert!(!ptr.is_null());
-        XCBVisualType(ptr)
+        ::Borrowed::new(XCBVisualType(ptr::NonNull::new_unchecked(ptr)))
     }
 
     pub unsafe fn from_raw_full(ptr: *mut ffi::xcb_visualtype_t) -> XCBVisualType {
         assert!(!ptr.is_null());
-        XCBVisualType(ptr)
+        XCBVisualType(ptr::NonNull::new_unchecked(ptr))
     }
 }
 
@@ -388,7 +391,7 @@ impl FromGlibPtrNone<*mut ffi::xcb_visualtype_t> for XCBVisualType {
 #[cfg(feature = "use_glib")]
 impl FromGlibPtrBorrow<*mut ffi::xcb_visualtype_t> for XCBVisualType {
     #[inline]
-    unsafe fn from_glib_borrow(ptr: *mut ffi::xcb_visualtype_t) -> XCBVisualType {
+    unsafe fn from_glib_borrow(ptr: *mut ffi::xcb_visualtype_t) -> ::Borrowed<XCBVisualType> {
         Self::from_raw_borrow(ptr)
     }
 }


### PR DESCRIPTION
For non-glib compilation copy the Borrowed struct definition from glib
and redefine it here.

Also move all structs around raw pointers to ptr::NonNull for allowing
further optimizations and more static guarantees.

See https://github.com/gtk-rs/glib/pull/605