### PR TITLE
Add missing fn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.39.0
+  - 1.40.0
 env:
   - GTK=3.14 FEATURES=
   - GTK=3.24 FEATURES=

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,6 @@ install:
   - SET PATH=C:\Users\appveyor\.cargo\bin;C:\msys64\mingw%BITS%\bin;%PATH%;C:\msys64\usr\bin
   - rustc -Vv
   - cargo -Vv
-  - pacman -Sy
   - pacman --noconfirm -S mingw-w64-%ARCH%-gtk3
 
 build_script:

--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -952,6 +952,13 @@ extern "C" {
     ) -> cairo_status_t;
     pub fn cairo_surface_get_reference_count(surface: *mut cairo_surface_t) -> c_uint;
     pub fn cairo_surface_mark_dirty(surface: *mut cairo_surface_t);
+    pub fn cairo_surface_mark_dirty_rectangle(
+        surface: *mut cairo_surface_t,
+        x: c_int,
+        y: c_int,
+        width: c_int,
+        height: c_int,
+    );
     pub fn cairo_surface_create_similar(
         surface: *mut cairo_surface_t,
         content: cairo_content_t,

--- a/src/image_surface.rs
+++ b/src/image_surface.rs
@@ -122,7 +122,7 @@ impl<'a> ImageSurfaceData<'a> {
 impl<'a> Drop for ImageSurfaceData<'a> {
     fn drop(&mut self) {
         if self.dirty {
-            unsafe { ffi::cairo_surface_mark_dirty(self.surface.to_raw_none()) }
+            self.surface.mark_dirty()
         }
     }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -6,8 +6,8 @@ use enums::{PathDataType, Status};
 use ffi;
 use ffi::cairo_path_t;
 use std::fmt;
-use std::ptr;
 use std::iter::Iterator;
+use std::ptr;
 
 #[derive(Debug)]
 pub struct Path(ptr::NonNull<cairo_path_t>);

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -245,6 +245,14 @@ impl Surface {
         }
     }
 
+    pub fn mark_dirty(&self) {
+        unsafe { ffi::cairo_surface_mark_dirty(self.to_raw_none()) }
+    }
+
+    pub fn mark_dirty_rectangle(&self, x: i32, y: i32, width: i32, height: i32) {
+        unsafe { ffi::cairo_surface_mark_dirty_rectangle(self.to_raw_none(), x, y, width, height) }
+    }
+
     user_data_methods! {
         ffi::cairo_surface_get_user_data,
         ffi::cairo_surface_set_user_data,

--- a/src/user_data.rs
+++ b/src/user_data.rs
@@ -36,9 +36,11 @@ impl<T> UserDataKey<T> {
 macro_rules! user_data_methods {
     ($ffi_get_user_data: path, $ffi_set_user_data: path,) => {
         /// Attach user data to `self` for the given `key`.
-        pub fn set_user_data<T: 'static>(&self, key: &'static crate::UserDataKey<T>,
-                                         value: std::rc::Rc<T>)
-        {
+        pub fn set_user_data<T: 'static>(
+            &self,
+            key: &'static crate::UserDataKey<T>,
+            value: std::rc::Rc<T>,
+        ) {
             unsafe extern "C" fn destructor<T>(ptr: *mut libc::c_void) {
                 let ptr: *const T = ptr as _;
                 drop(std::rc::Rc::from_raw(ptr))
@@ -58,9 +60,10 @@ macro_rules! user_data_methods {
         }
 
         /// Return the user data previously attached to `self` with the given `key`, if any.
-        pub fn get_user_data<T: 'static>(&self, key: &'static crate::UserDataKey<T>)
-                                         -> Option<std::rc::Rc<T>>
-        {
+        pub fn get_user_data<T: 'static>(
+            &self,
+            key: &'static crate::UserDataKey<T>,
+        ) -> Option<std::rc::Rc<T>> {
             let ptr = self.get_user_data_ptr(key)?.as_ptr();
 
             // Safety:
@@ -82,9 +85,10 @@ macro_rules! user_data_methods {
         /// The pointer is valid when it is returned from this method,
         /// until the cairo object that `self` represents is destroyed
         /// or `remove_user_data` or `set_user_data` is called with the same key.
-        pub fn get_user_data_ptr<T: 'static>(&self, key: &'static crate::UserDataKey<T>)
-                                             -> Option<std::ptr::NonNull<T>>
-        {
+        pub fn get_user_data_ptr<T: 'static>(
+            &self,
+            key: &'static crate::UserDataKey<T>,
+        ) -> Option<std::ptr::NonNull<T>> {
             // Safety:
             //
             // If `ffi_get_user_data` returns a non-null pointer,


### PR DESCRIPTION
Fixes #316.

Considering the current implementation, I don't see where we could add a safe high-level binding for this function though... Maybe allow to call it on `ImageSurface` through an unsafe function?

cc @EPashkin @sdroege @Kinnison