### PR TITLE
errors: derive Error from common enum traits

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 use std::io;
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone, PartialEq, PartialOrd, Copy, Eq)]
 #[non_exhaustive]
 pub enum Error {
     #[error("No Memory")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 use std::io;
 use thiserror::Error;
 
-#[derive(Error, Debug, Clone, PartialEq, PartialOrd, Copy, Eq)]
+#[derive(Error, Debug, Clone, PartialEq, Copy, Eq)]
 #[non_exhaustive]
 pub enum Error {
     #[error("No Memory")]


### PR DESCRIPTION
Required to update librsvg to use the new cairo release
