### PR TITLE
Fix README link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Cairo bindings for Rust.
 
 - [Gtk-rs project site](http://gtk-rs.org/)
 
-- [Online documentation](http://gtk-rs.org/docs/)
+- [Online documentation](https://gtk-rs.org/docs-src/)
 
 - [Readme](https://github.com/gtk-rs/gtk/blob/master/README.md) in our
   [main repo](https://github.com/gtk-rs/gtk)


### PR DESCRIPTION
The previous link was a 404