### PR TITLE
Add wrapper for `cairo_ft_font_face_create_for_ft_face`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ use_glib = ["glib", "glib-sys", "gobject-sys", "cairo-sys-rs/use_glib"]
 embed-lgpl-docs = ["gtk-rs-lgpl-docs"]
 v1_14 = ["cairo-sys-rs/v1_14"]
 v1_16 = ["v1_14", "cairo-sys-rs/v1_16"]
-default = ["use_glib", "use_freetype"]
-use_freetype = ["cairo-sys-rs/freetype", "freetype"]
+default = ["use_glib", "freetype"]
+freetype = ["cairo-sys-rs/freetype", "freetype-crate"]
 script = ["cairo-sys-rs/script"]
 xcb = ["cairo-sys-rs/xcb"]
 xlib = ["cairo-sys-rs/xlib"]
@@ -59,11 +59,15 @@ git = "https://github.com/gtk-rs/sys"
 optional = true
 git = "https://github.com/gtk-rs/sys"
 
+[dependencies.freetype-crate]
+package = "freetype"
+version = "0.7.0"
+optional = true
+
 [dependencies]
 libc = "0.2"
 bitflags = "1.0"
 thiserror = "1.0.10"
-freetype = { version = "0.7.0", optional = true }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ use_glib = ["glib", "glib-sys", "gobject-sys", "cairo-sys-rs/use_glib"]
 embed-lgpl-docs = ["gtk-rs-lgpl-docs"]
 v1_14 = ["cairo-sys-rs/v1_14"]
 v1_16 = ["v1_14", "cairo-sys-rs/v1_16"]
-default = ["use_glib", "freetype"]
-freetype = ["cairo-sys-rs/freetype"]
+default = ["use_glib", "use_freetype"]
+use_freetype = ["cairo-sys-rs/freetype", "freetype"]
 script = ["cairo-sys-rs/script"]
 xcb = ["cairo-sys-rs/xcb"]
 xlib = ["cairo-sys-rs/xlib"]
@@ -63,6 +63,7 @@ git = "https://github.com/gtk-rs/sys"
 libc = "0.2"
 bitflags = "1.0"
 thiserror = "1.0.10"
+freetype = { version = "0.7.0", optional = true }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -753,7 +753,8 @@ extern "C" {
         load_flags: c_int,
     ) -> *mut cairo_font_face_t;
     #[cfg(any(feature = "freetype", feature = "dox"))]
-    pub fn cairo_ft_font_face_create_for_pattern(pattern: *mut FcPattern) -> *mut cairo_font_face_t;
+    pub fn cairo_ft_font_face_create_for_pattern(pattern: *mut FcPattern)
+        -> *mut cairo_font_face_t;
     #[cfg(any(feature = "freetype", feature = "dox"))]
     pub fn cairo_ft_font_option_substitute(
         options: *const cairo_font_options_t,

--- a/cairo-sys-rs/src/lib.rs
+++ b/cairo-sys-rs/src/lib.rs
@@ -275,6 +275,11 @@ pub type cairo_read_func_t =
 pub type cairo_write_func_t =
     Option<unsafe extern "C" fn(*mut c_void, *mut c_uchar, c_uint) -> cairo_status_t>;
 
+#[cfg(any(feature = "freetype", feature = "dox"))]
+pub type FT_Face = *mut c_void;
+#[cfg(any(feature = "freetype", feature = "dox"))]
+pub type FcPattern = c_void;
+
 extern "C" {
     // CAIRO CONTEXT
     pub fn cairo_create(target: *mut cairo_surface_t) -> *mut cairo_t;
@@ -742,6 +747,22 @@ extern "C" {
     pub fn cairo_text_cluster_allocate(num_clusters: c_int) -> *mut TextCluster;
     pub fn cairo_text_cluster_free(clusters: *mut TextCluster);
 
+    #[cfg(any(feature = "freetype", feature = "dox"))]
+    pub fn cairo_ft_font_face_create_for_ft_face(
+        face: FT_Face,
+        load_flags: c_int,
+    ) -> *mut cairo_font_face_t;
+    #[cfg(any(feature = "freetype", feature = "dox"))]
+    pub fn cairo_ft_font_face_create_for_pattern(pattern: *mut FcPattern) -> *mut cairo_font_face_t;
+    #[cfg(any(feature = "freetype", feature = "dox"))]
+    pub fn cairo_ft_font_option_substitute(
+        options: *const cairo_font_options_t,
+        pattern: *mut FcPattern,
+    );
+    #[cfg(any(feature = "freetype", feature = "dox"))]
+    pub fn cairo_ft_scaled_font_lock_face(scaled_font: *mut cairo_scaled_font_t) -> FT_Face;
+    #[cfg(any(feature = "freetype", feature = "dox"))]
+    pub fn cairo_ft_scaled_font_unlock_face(scaled_font: *mut cairo_scaled_font_t);
     #[cfg(any(feature = "freetype", feature = "dox"))]
     pub fn cairo_ft_font_face_get_synthesize(
         font_face: *mut cairo_font_face_t,

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1754,7 +1754,7 @@ impl fmt::Display for MeshCorner {
     }
 }
 
-#[cfg(any(feature = "freetype", feature = "dox"))]
+#[cfg(any(feature = "use_freetype", feature = "dox"))]
 #[derive(Clone, PartialEq, PartialOrd, Debug, Copy)]
 #[non_exhaustive]
 pub enum FtSynthesize {
@@ -1764,7 +1764,7 @@ pub enum FtSynthesize {
     __Unknown(u32),
 }
 
-#[cfg(any(feature = "freetype", feature = "dox"))]
+#[cfg(any(feature = "use_freetype", feature = "dox"))]
 #[doc(hidden)]
 impl Into<ffi::cairo_ft_synthesize_t> for FtSynthesize {
     fn into(self) -> ffi::cairo_ft_synthesize_t {
@@ -1776,7 +1776,7 @@ impl Into<ffi::cairo_ft_synthesize_t> for FtSynthesize {
     }
 }
 
-#[cfg(any(feature = "freetype", feature = "dox"))]
+#[cfg(any(feature = "use_freetype", feature = "dox"))]
 #[doc(hidden)]
 impl From<ffi::cairo_ft_synthesize_t> for FtSynthesize {
     fn from(value: ffi::cairo_ft_synthesize_t) -> Self {
@@ -1788,7 +1788,7 @@ impl From<ffi::cairo_ft_synthesize_t> for FtSynthesize {
     }
 }
 
-#[cfg(any(feature = "freetype", feature = "dox"))]
+#[cfg(any(feature = "use_freetype", feature = "dox"))]
 impl fmt::Display for FtSynthesize {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1754,7 +1754,7 @@ impl fmt::Display for MeshCorner {
     }
 }
 
-#[cfg(any(feature = "use_freetype", feature = "dox"))]
+#[cfg(any(feature = "freetype", feature = "dox"))]
 #[derive(Clone, PartialEq, PartialOrd, Debug, Copy)]
 #[non_exhaustive]
 pub enum FtSynthesize {
@@ -1764,7 +1764,7 @@ pub enum FtSynthesize {
     __Unknown(u32),
 }
 
-#[cfg(any(feature = "use_freetype", feature = "dox"))]
+#[cfg(any(feature = "freetype", feature = "dox"))]
 #[doc(hidden)]
 impl Into<ffi::cairo_ft_synthesize_t> for FtSynthesize {
     fn into(self) -> ffi::cairo_ft_synthesize_t {
@@ -1776,7 +1776,7 @@ impl Into<ffi::cairo_ft_synthesize_t> for FtSynthesize {
     }
 }
 
-#[cfg(any(feature = "use_freetype", feature = "dox"))]
+#[cfg(any(feature = "freetype", feature = "dox"))]
 #[doc(hidden)]
 impl From<ffi::cairo_ft_synthesize_t> for FtSynthesize {
     fn from(value: ffi::cairo_ft_synthesize_t) -> Self {
@@ -1788,7 +1788,7 @@ impl From<ffi::cairo_ft_synthesize_t> for FtSynthesize {
     }
 }
 
-#[cfg(any(feature = "use_freetype", feature = "dox"))]
+#[cfg(any(feature = "freetype", feature = "dox"))]
 impl fmt::Display for FtSynthesize {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(

--- a/src/font/font_face.rs
+++ b/src/font/font_face.rs
@@ -8,7 +8,7 @@ use std::ptr;
 
 use enums::{FontSlant, FontType, FontWeight};
 
-#[cfg(any(feature = "use_freetype", feature = "dox"))]
+#[cfg(any(feature = "freetype", feature = "dox"))]
 use enums::FtSynthesize;
 
 use utils::status_to_result;
@@ -45,8 +45,8 @@ impl FontFace {
     }
 
     // Safety: the FT_Face must be valid and not be freed until the `FontFace` is dropped.
-    #[cfg(any(feature = "use_freetype", feature = "dox"))]
-    pub unsafe fn create_from_ft(face: freetype::freetype::FT_Face) -> FontFace {
+    #[cfg(any(feature = "freetype", feature = "dox"))]
+    pub unsafe fn create_from_ft(face: freetype_crate::freetype::FT_Face) -> FontFace {
         let font_face = FontFace::from_raw_full(ffi::cairo_ft_font_face_create_for_ft_face(
             face as *mut _,
             0,
@@ -57,9 +57,9 @@ impl FontFace {
     }
 
     // Safety: the FT_Face must be valid and not be freed until the `FontFace` is dropped.
-    #[cfg(any(feature = "use_freetype", feature = "dox"))]
+    #[cfg(any(feature = "freetype", feature = "dox"))]
     pub unsafe fn create_from_ft_with_flags(
-        face: freetype::freetype::FT_Face,
+        face: freetype_crate::freetype::FT_Face,
         load_flags: c_int,
     ) -> FontFace {
         let font_face = FontFace::from_raw_full(ffi::cairo_ft_font_face_create_for_ft_face(
@@ -123,17 +123,17 @@ impl FontFace {
         unsafe { ffi::cairo_font_face_get_reference_count(self.to_raw_none()) as usize }
     }
 
-    #[cfg(any(feature = "use_freetype", feature = "dox"))]
+    #[cfg(any(feature = "freetype", feature = "dox"))]
     pub fn get_synthesize(&self) -> FtSynthesize {
         unsafe { FtSynthesize::from(ffi::cairo_ft_font_face_get_synthesize(self.to_raw_none())) }
     }
 
-    #[cfg(any(feature = "use_freetype", feature = "dox"))]
+    #[cfg(any(feature = "freetype", feature = "dox"))]
     pub fn set_synthesize(&self, synth_flags: FtSynthesize) {
         unsafe { ffi::cairo_ft_font_face_set_synthesize(self.to_raw_none(), synth_flags.into()) }
     }
 
-    #[cfg(any(feature = "use_freetype", feature = "dox"))]
+    #[cfg(any(feature = "freetype", feature = "dox"))]
     pub fn unset_synthesize(&self, synth_flags: FtSynthesize) {
         unsafe { ffi::cairo_ft_font_face_unset_synthesize(self.to_raw_none(), synth_flags.into()) }
     }

--- a/src/font/font_face.rs
+++ b/src/font/font_face.rs
@@ -44,12 +44,6 @@ impl FontFace {
         font_face
     }
 
-    // Safety: the FT_Face must be valid and not be freed until the `FontFace` is dropped.
-    #[cfg(any(feature = "freetype", feature = "dox"))]
-    pub unsafe fn create_from_ft(face: ffi::FT_Face) -> FontFace {
-        FontFace::from_raw_full(ffi::cairo_ft_font_face_create_for_ft_face(face, 0))
-    }
-
     #[cfg(feature = "use_glib")]
     pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_font_face_t) -> FontFace {
         from_glib_full(ptr)

--- a/src/font/font_face.rs
+++ b/src/font/font_face.rs
@@ -44,6 +44,12 @@ impl FontFace {
         font_face
     }
 
+    // Safety: the FT_Face must be valid and not be freed until the `FontFace` is dropped.
+    #[cfg(any(feature = "freetype", feature = "dox"))]
+    pub unsafe fn create_from_ft(face: ffi::FT_Face) -> FontFace {
+        FontFace::from_raw_full(ffi::cairo_ft_font_face_create_for_ft_face(face, 0))
+    }
+
     #[cfg(feature = "use_glib")]
     pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_font_face_t) -> FontFace {
         from_glib_full(ptr)

--- a/src/font/font_face.rs
+++ b/src/font/font_face.rs
@@ -123,11 +123,7 @@ impl FontFace {
         unsafe { ffi::cairo_font_face_get_reference_count(self.to_raw_none()) as usize }
     }
 
-    #[cfg(any(
-        feature = "use_
-            reetype",
-        feature = "dox"
-    ))]
+    #[cfg(any(feature = "use_freetype", feature = "dox"))]
     pub fn get_synthesize(&self) -> FtSynthesize {
         unsafe { FtSynthesize::from(ffi::cairo_ft_font_face_get_synthesize(self.to_raw_none())) }
     }


### PR DESCRIPTION
I'm opening this PR for feedback initially. I need to be able to access `cairo_ft_font_face_create_for_ft_face` to be able to migrate [`druid`](https://github.com/linebender/druid) away from the toy text API. I've implemented the function here, but there are some things I'm unsure of:

 1. Types to use for the external types (`FT_Face` and `FcPattern`). I think this create should just define placeholder versions of these types. They are both treated as opaque pointers, so we can leave it up to the user to cast the pointer, knowing that it has come from freetype/fontconfig. That's how I've implemented it in this patch currently.
 2. Handling ownership of the font returned by `cairo_ft_font_face_create_for_ft_face`. The user supplied `FT_Face` must outlive the cairo font object, but I don't think it's possible to enforce this. Someone could write a library using both this and [`freetype`](https://docs.rs/freetype-rs/0.26.0/freetype/) and make the interface fully safe.
 3. A wrapper for `cairo_ft_font_face_create_for_pattern`. I know little of fontconfig and don't need this for my work.

This PR would at least partially address #282.