### PR TITLE
Re-export cairo-sys as `ffi`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! * **win32-surface** - Microsoft Windows surface support
 
-extern crate cairo_sys as ffi;
+pub extern crate cairo_sys as ffi;
 extern crate libc;
 extern crate thiserror;
 


### PR DESCRIPTION
Closes #342 

2 questions:

 - Do you prefer with `doc(inline)` or without? Run `cargo doc` with and without to see the difference.
 - What other crates should I do this for?