### PR TITLE
Add an unsafe variant of ImageSurface::create_for_data

### DIFF
--- a/src/image_surface.rs
+++ b/src/image_surface.rs
@@ -31,12 +31,11 @@ impl ImageSurface {
         }
     }
 
-    /**
-     * Creates an image surface for the provided pixel data.
-     * The pointer `data` is the beginning of the underlying slice,
-     * and at least `width * stride` succeeding bytes should be allocated.
-     * Additionally, `data` must live longer than any reference to the returned surface.
-     */
+    /// Creates an image surface for the provided pixel data.
+    /// - The pointer `data` is the beginning of the underlying slice,
+    ///   and at least `width * stride` succeeding bytes should be allocated.
+    /// - `data` must live longer than any reference to the returned surface.
+    /// - You have to free `data` by yourself.
     pub unsafe fn create_for_data_unsafe(
         data: *mut u8,
         format: Format,
@@ -44,8 +43,13 @@ impl ImageSurface {
         height: i32,
         stride: i32,
     ) -> Result<ImageSurface, Error> {
-        let data = std::slice::from_raw_parts_mut(data, (stride * height) as usize);
-        Self::create_for_data(data, format, width, height, stride)
+        ImageSurface::from_raw_full(ffi::cairo_image_surface_create_for_data(
+            data,
+            format.into(),
+            width,
+            height,
+            stride,
+        ))
     }
 
     pub fn create_for_data<D: AsMut<[u8]> + 'static>(

--- a/src/image_surface.rs
+++ b/src/image_surface.rs
@@ -31,6 +31,7 @@ impl ImageSurface {
         }
     }
 
+    // rustdoc-stripper-ignore-next
     /// Creates an image surface for the provided pixel data.
     /// - The pointer `data` is the beginning of the underlying slice,
     ///   and at least `width * stride` succeeding bytes should be allocated.

--- a/src/image_surface.rs
+++ b/src/image_surface.rs
@@ -31,6 +31,23 @@ impl ImageSurface {
         }
     }
 
+    /**
+     * Creates an image surface for the provided pixel data.
+     * The pointer `data` is the beginning of the underlying slice,
+     * and at least `width * stride` succeeding bytes should be allocated.
+     * Additionally, `data` must live longer than any reference to the returned surface.
+     */
+    pub unsafe fn create_for_data_unsafe(
+        data: *mut u8,
+        format: Format,
+        width: i32,
+        height: i32,
+        stride: i32,
+    ) -> Result<ImageSurface, Error> {
+        let data = std::slice::from_raw_parts_mut(data, (stride * height) as usize);
+        Self::create_for_data(data, format, width, height, stride)
+    }
+
     pub fn create_for_data<D: AsMut<[u8]> + 'static>(
         data: D,
         format: Format,


### PR DESCRIPTION
Closes #344 

### Discussion:
- There are several candidates for how to receive `data` as argument:
  - Receive only the beginning pointer (the current one)
  - Receive the beginning pointer and the length of slice
  - Receive `Range<*mut u8>` (in favor of [`slice::as_mut_ptr_range`](https://doc.rust-lang.org/std/primitive.slice.html#method.as_mut_ptr_range))

### Foodnote:
Any suggestion, including grammatical mistakes of unnatural English in the documentation, is welcome.